### PR TITLE
feat(ui): overhaul visual design with custom MUI theme and layout improvements

### DIFF
--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -2,6 +2,9 @@
 
 import Loading from '@/components/design/Loading';
 import useBand from '@/hooks/useBand';
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
 import { ReactNode } from 'react';
 import { BandRouteProps } from './types';
 
@@ -22,11 +25,16 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
   if (band) {
     return (
       <>
-        <h2>{band.name}</h2>
-        <div>{children}</div>
+        <Box sx={{ pt: 3, pb: 2 }}>
+          <Typography variant="h4" fontWeight={700} color="text.primary">
+            {band.name}
+          </Typography>
+          <Divider sx={{ mt: 2 }} />
+        </Box>
+        <Box>{children}</Box>
       </>
     );
   }
 
-  return <h2>Whoops!</h2>;
+  return <Typography variant="h5">Band not found.</Typography>;
 }

--- a/app/band/[bandId]/setlists/page.tsx
+++ b/app/band/[bandId]/setlists/page.tsx
@@ -5,6 +5,7 @@ import Table, { TableProps, TablePropsDataType } from '@/components/design/Table
 import { adaptSetlist } from '@/components/setlistEditor/helpers';
 import useSetlists from '@/hooks/useSetlists';
 import useSongs from '@/hooks/useSongs';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -94,10 +95,15 @@ export default function BandSetlistsPage({ params }: Readonly<BandRouteProps>) {
   return (
     <>
       {pageContent}
-      <hr />
-      <Link href={`/band/${bandId}/setlists/create`}>
-        <Button variant="contained">Create a Setlist</Button>
-      </Link>
+      <Box sx={{ mt: 3 }}>
+        <Button
+          component={Link}
+          href={`/band/${bandId}/setlists/create`}
+          variant="contained"
+        >
+          Create a Setlist
+        </Button>
+      </Box>
     </>
   );
 }

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -4,6 +4,7 @@ import Loading from '@/components/design/Loading';
 import Table, { TableProps, TablePropsDataType, TableRow } from '@/components/design/Table';
 import SongCommentsModal from '@/components/modals/SongCommentsModal';
 import useSongs, { SongsComposite } from '@/hooks/useSongs';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Link from 'next/link';
 import prettyMilliseconds from 'pretty-ms';
@@ -77,10 +78,15 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
   return (
     <>
       {pageContent}
-      <hr />
-      <Link href={`/band/${bandId}/songs/spotify-import`}>
-        <Button variant="contained">Import Songs From Spotify</Button>
-      </Link>
+      <Box sx={{ mt: 3 }}>
+        <Button
+          component={Link}
+          href={`/band/${bandId}/songs/spotify-import`}
+          variant="contained"
+        >
+          Import Songs From Spotify
+        </Button>
+      </Box>
     </>
   );
 }

--- a/app/band/create/page.tsx
+++ b/app/band/create/page.tsx
@@ -1,10 +1,17 @@
 import BandForm from '@/components/forms/BandForm';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 
 export default async function Index() {
   return (
-    <div>
-      <h2>Create a band</h2>
+    <Box sx={{ pt: 3, maxWidth: 480 }}>
+      <Typography variant="h5" fontWeight={700} mb={0.5}>
+        Create a band
+      </Typography>
+      <Typography variant="body2" color="text.secondary" mb={3}>
+        Give your band a name to get started.
+      </Typography>
       <BandForm />
-    </div>
+    </Box>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,25 +4,25 @@
 
 @layer base {
   :root {
-    --background: 200 20% 98%;
-    --btn-background: 200 10% 91%;
-    --btn-background-hover: 200 10% 89%;
-    --foreground: 200 50% 3%;
+    --background: 0 60% 98%;
+    --foreground: 0 85% 6%;
+    --btn-background: 0 30% 91%;
+    --btn-background-hover: 0 30% 86%;
   }
 
   @media (prefers-color-scheme: dark) {
     :root {
-      --background: 200 50% 3%;
-      --btn-background: 200 10% 9%;
-      --btn-background-hover: 200 10% 12%;
-      --foreground: 200 20% 96%;
+      --background: 345 50% 4%;
+      --foreground: 0 85% 97%;
+      --btn-background: 345 30% 12%;
+      --btn-background-hover: 345 30% 17%;
     }
   }
 }
 
 @layer base {
   * {
-    @apply border-foreground/20;
+    @apply border-foreground/10;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,10 @@
 import Footer from '@/components/layout/Footer';
 import Header from '@/components/layout/Header';
+import ThemeRegistry from '@/components/ThemeRegistry';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
 import { GeistSans } from 'geist/font/sans';
 import { ReactNode } from 'react';
 import './globals.css';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -24,14 +25,16 @@ export default function RootLayout({ children }: Readonly<RootLayoutProps>) {
   return (
     <AppRouterCacheProvider options={{ enableCssLayer: true }}>
       <html lang="en" className={GeistSans.className}>
-        <body className="bg-background text-foreground">
-          <div className="min-h-screen flex-1 w-full flex flex-col items-center">
-            <Header />
-            <main className="flex flex-col items-center grow w-full">
-              <div className="w-full max-w-4xl p-3 ">{children}</div>
-            </main>
-            <Footer />
-          </div>
+        <body>
+          <ThemeRegistry>
+            <div className="min-h-screen flex-1 w-full flex flex-col items-center">
+              <Header />
+              <main className="flex flex-col items-center grow w-full">
+                <div className="w-full max-w-4xl p-3">{children}</div>
+              </main>
+              <Footer />
+            </div>
+          </ThemeRegistry>
         </body>
       </html>
     </AppRouterCacheProvider>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,10 @@
 import LoginForm from '@/components/forms/LoginForm';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import NextLink from 'next/link';
 
 interface LoginPageProps {
   searchParams: {
@@ -7,5 +13,25 @@ interface LoginPageProps {
 }
 
 export default function LoginPage({ searchParams }: Readonly<LoginPageProps>) {
-  return <LoginForm errorMessage={searchParams.message} />;
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
+      <Card sx={{ width: '100%', maxWidth: 420 }}>
+        <CardContent sx={{ p: 4 }}>
+          <Typography variant="h5" fontWeight={700} mb={0.5}>
+            Welcome back
+          </Typography>
+          <Typography variant="body2" color="text.secondary" mb={3}>
+            Log in to manage your band
+          </Typography>
+          <LoginForm errorMessage={searchParams.message} />
+          <Typography variant="body2" color="text.secondary" mt={3}>
+            Don&apos;t have an account?{' '}
+            <Link component={NextLink} href="/signup" underline="hover" color="primary">
+              Sign up
+            </Link>
+          </Typography>
+        </CardContent>
+      </Card>
+    </Box>
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,33 +1,55 @@
 import Bands from '@/components/Bands';
 import useAuthUser from '@/hooks/useAuthUser';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import NextLink from 'next/link';
 
 export default async function IndexPage() {
   const user = await useAuthUser();
 
   return (
-    <div className="animate-in">
-      <h2 className="font-bold text-2xl mb-4">
-        Welcome to your one-stop band management shop!
-      </h2>
+    <Box className="animate-in">
       {user ? (
-        <Bands />
-      ) : (
         <>
-          <p className="my-2">
-            Being in a band is <span className="italic">SUPPOSED TO BE</span>{' '}
-            fun.
-          </p>
-          <p className="my-2">
-            Keeping track of your setlists, song lists, and all of the other{' '}
-            <span className="italic">administrative band things</span> in
-            various spreadsheets and documents is not!
-          </p>
-          <p className="my-2">
-            We&apos;re here to keep track of all of that stuff for you. Log in
-            and get started!
-          </p>
+          <Typography variant="h5" fontWeight={700} mb={3}>
+            Your Bands
+          </Typography>
+          <Bands />
         </>
+      ) : (
+        <Box sx={{ maxWidth: 560, pt: 6, pb: 4 }}>
+          <Typography variant="h3" fontWeight={700} mb={2} lineHeight={1.2}>
+            Your band, without the headache.
+          </Typography>
+          <Typography variant="body1" color="text.secondary" mb={2}>
+            Being in a band is <em>supposed to be</em> fun. Keeping track of
+            setlists, song lists, and all the other{' '}
+            <em>administrative band things</em> in spreadsheets is not.
+          </Typography>
+          <Typography variant="body1" color="text.secondary" mb={4}>
+            Band Manager handles the boring stuff so you can focus on the music.
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <Button
+              component={NextLink}
+              href="/login"
+              variant="contained"
+              size="large"
+            >
+              Log in
+            </Button>
+            <Button
+              component={NextLink}
+              href="/signup"
+              variant="outlined"
+              size="large"
+            >
+              Sign up
+            </Button>
+          </Box>
+        </Box>
       )}
-    </div>
+    </Box>
   );
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,4 +1,10 @@
 import SignUpForm from '@/components/forms/SignUpForm';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import NextLink from 'next/link';
 
 interface SignUpPageProps {
   searchParams: {
@@ -7,5 +13,25 @@ interface SignUpPageProps {
 }
 
 export default function SignUpPage({ searchParams }: Readonly<SignUpPageProps>) {
-  return <SignUpForm errorMessage={searchParams.message} />;
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
+      <Card sx={{ width: '100%', maxWidth: 420 }}>
+        <CardContent sx={{ p: 4 }}>
+          <Typography variant="h5" fontWeight={700} mb={0.5}>
+            Create an account
+          </Typography>
+          <Typography variant="body2" color="text.secondary" mb={3}>
+            Join Band Manager and get organized
+          </Typography>
+          <SignUpForm errorMessage={searchParams.message} />
+          <Typography variant="body2" color="text.secondary" mt={3}>
+            Already have an account?{' '}
+            <Link component={NextLink} href="/login" underline="hover" color="primary">
+              Log in
+            </Link>
+          </Typography>
+        </CardContent>
+      </Card>
+    </Box>
+  );
 }

--- a/components/Bands.tsx
+++ b/components/Bands.tsx
@@ -5,10 +5,13 @@ import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
 import PeopleIcon from '@mui/icons-material/People';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
+import MuiLink from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
 import Link from 'next/link';
-import Loading from './design/Loading';
 import Card from './design/Card';
+import Loading from './design/Loading';
 
 export default function Bands() {
   const { data, isLoading } = useBands();
@@ -19,51 +22,54 @@ export default function Bands() {
 
   if (!data?.length) {
     return (
-      <div>
-        It looks like you haven&apos;t made any bands yet.{' '}
-        <Link href="/band/create">Create one now!</Link>
-      </div>
+      <Box sx={{ py: 4 }}>
+        <Typography color="text.secondary">
+          You haven&apos;t created any bands yet.{' '}
+          <MuiLink component={Link} href="/band/create" underline="hover" color="primary" fontWeight={600}>
+            Create one now!
+          </MuiLink>
+        </Typography>
+      </Box>
     );
   }
 
-  if (data.length) {
-    return (
-      <>
-        <Grid container spacing={2} justifyContent="flex-start" alignItems="center">
-          {data.map(({ id, name, songs, band_members }) => {
-            const bandCardDescription = (
-              <>
-                <Box>
-                  <PeopleIcon titleAccess="Count of Members" />: {band_members[0]['count']}
-                </Box>
-                <Box>
-                  <LibraryMusicIcon titleAccess="Count of Songs" />: {songs[0]['count']}
-                </Box>
-              </>
-            );
-
-            const bandCardLink = `/band/${id}`;
-
-            const bandCardClassName = 'md:basis-1/3 sm:basis-1/2 basis-full';
-
-            return (
-              <Card
-                key={id}
-                title={name}
-                description={bandCardDescription}
-                link={bandCardLink}
-                className={bandCardClassName}
+  return (
+    <>
+      <Grid container spacing={2} justifyContent="flex-start" alignItems="stretch">
+        {data.map(({ id, name, songs, band_members }) => {
+          const bandCardDescription = (
+            <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
+              <Chip
+                icon={<PeopleIcon />}
+                label={`${band_members[0]['count']} member${band_members[0]['count'] !== 1 ? 's' : ''}`}
+                size="small"
+                variant="outlined"
               />
-            );
-          })}
-        </Grid>
-        <hr />
-        <div>
-          <Link href="/band/create">
-            <Button variant="contained">Add another band</Button>
-          </Link>
-        </div>
-      </>
-    );
-  }
+              <Chip
+                icon={<LibraryMusicIcon />}
+                label={`${songs[0]['count']} song${songs[0]['count'] !== 1 ? 's' : ''}`}
+                size="small"
+                variant="outlined"
+              />
+            </Box>
+          );
+
+          return (
+            <Card
+              key={id}
+              title={name}
+              description={bandCardDescription}
+              link={`/band/${id}`}
+              className="md:basis-1/3 sm:basis-1/2 basis-full"
+            />
+          );
+        })}
+      </Grid>
+      <Box sx={{ mt: 3 }}>
+        <Button component={Link} href="/band/create" variant="outlined">
+          Add another band
+        </Button>
+      </Box>
+    </>
+  );
 }

--- a/components/ThemeRegistry.tsx
+++ b/components/ThemeRegistry.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { ReactNode, useMemo } from 'react';
+
+// Deep crimson — raw energy, rock and roll, vintage venue marquees
+// Dark: near-black with a deep red undertone
+// Light: soft warm white with rich crimson accents
+function buildTheme(dark: boolean) {
+  return createTheme({
+    palette: {
+      mode: dark ? 'dark' : 'light',
+      primary: {
+        main: dark ? '#f87171' : '#b91c1c',
+        light: dark ? '#fca5a5' : '#dc2626',
+        dark: dark ? '#ef4444' : '#991b1b',
+        contrastText: dark ? '#0d0305' : '#ffffff',
+      },
+      secondary: {
+        main: dark ? '#94a3b8' : '#475569',
+        light: dark ? '#cbd5e1' : '#64748b',
+        dark: dark ? '#64748b' : '#334155',
+        contrastText: '#ffffff',
+      },
+      background: {
+        default: dark ? '#0d0507' : '#fdf8f8',
+        paper: dark ? '#1a0b0d' : '#ffffff',
+      },
+      text: {
+        primary: dark ? '#fef2f2' : '#1a0505',
+        secondary: dark ? '#fca5a5' : '#7f1d1d',
+      },
+      divider: dark ? 'rgba(248,113,113,0.12)' : 'rgba(185,28,28,0.12)',
+      error: { main: dark ? '#fb923c' : '#ea580c' },
+      success: { main: dark ? '#86efac' : '#15803d' },
+      warning: { main: dark ? '#fde68a' : '#d97706' },
+    },
+    typography: {
+      fontFamily: 'var(--font-geist-sans), system-ui, sans-serif',
+      h1: { fontWeight: 700 },
+      h2: { fontWeight: 700 },
+      h3: { fontWeight: 600 },
+      h4: { fontWeight: 600 },
+      h5: { fontWeight: 600 },
+      h6: { fontWeight: 600 },
+    },
+    shape: {
+      borderRadius: 10,
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            scrollbarColor: dark ? '#3d1015 #0d0507' : '#f5c6c6 #fdf8f8',
+          },
+        },
+      },
+      MuiAppBar: {
+        defaultProps: { elevation: 0 },
+        styleOverrides: {
+          root: {
+            backgroundColor: dark ? '#0d0507' : '#991b1b',
+            borderBottom: dark ? '1px solid rgba(248,113,113,0.15)' : 'none',
+          },
+        },
+      },
+      MuiCard: {
+        defaultProps: { elevation: 0 },
+        styleOverrides: {
+          root: ({ theme }) => ({
+            border: `1px solid ${theme.palette.divider}`,
+            transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
+            '&:hover': {
+              boxShadow: dark
+                ? '0 4px 32px rgba(248,113,113,0.1)'
+                : '0 4px 24px rgba(185,28,28,0.1)',
+              borderColor: dark ? 'rgba(248,113,113,0.35)' : 'rgba(185,28,28,0.3)',
+            },
+          }),
+        },
+      },
+      MuiPaper: {
+        defaultProps: { elevation: 0 },
+        styleOverrides: {
+          root: ({ theme }) => ({
+            backgroundImage: 'none',
+            border: `1px solid ${theme.palette.divider}`,
+          }),
+        },
+      },
+      MuiTableHead: {
+        styleOverrides: {
+          root: {
+            '& .MuiTableCell-head': {
+              fontWeight: 600,
+              fontSize: '0.75rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              backgroundColor: dark ? 'rgba(13,5,7,0.7)' : 'rgba(253,248,248,0.8)',
+              color: dark ? '#fca5a5' : '#7f1d1d',
+            },
+          },
+        },
+      },
+      MuiTableRow: {
+        styleOverrides: {
+          root: {
+            '&:last-child td': { border: 0 },
+            '&:hover': {
+              backgroundColor: dark ? 'rgba(248,113,113,0.05)' : 'rgba(185,28,28,0.03)',
+            },
+          },
+        },
+      },
+      MuiButton: {
+        defaultProps: { disableElevation: true },
+        styleOverrides: {
+          root: {
+            textTransform: 'none',
+            fontWeight: 600,
+            borderRadius: 8,
+          },
+        },
+      },
+      MuiLoadingButton: {
+        defaultProps: { disableElevation: true },
+        styleOverrides: {
+          root: {
+            textTransform: 'none',
+            fontWeight: 600,
+            borderRadius: 8,
+          },
+        },
+      },
+      MuiTextField: {
+        defaultProps: { variant: 'outlined', size: 'small' },
+      },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: {
+            borderRadius: 8,
+          },
+        },
+      },
+      MuiDialog: {
+        styleOverrides: {
+          paper: {
+            backgroundImage: 'none',
+          },
+        },
+      },
+      MuiTooltip: {
+        styleOverrides: {
+          tooltip: {
+            borderRadius: 6,
+            fontSize: '0.75rem',
+          },
+        },
+      },
+      MuiAvatar: {
+        styleOverrides: {
+          root: {
+            backgroundColor: dark ? '#ef4444' : '#b91c1c',
+            color: '#ffffff',
+            fontWeight: 700,
+          },
+        },
+      },
+      MuiChip: {
+        styleOverrides: {
+          root: {
+            borderRadius: 6,
+          },
+        },
+      },
+      MuiAlert: {
+        styleOverrides: {
+          root: {
+            borderRadius: 8,
+          },
+        },
+      },
+    },
+  });
+}
+
+interface ThemeRegistryProps {
+  children: ReactNode;
+}
+
+export default function ThemeRegistry({ children }: Readonly<ThemeRegistryProps>) {
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)', { noSsr: true });
+  const theme = useMemo(() => buildTheme(prefersDarkMode), [prefersDarkMode]);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/components/design/Card.tsx
+++ b/components/design/Card.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box';
 import MUICard from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import Link from 'next/link';
@@ -19,37 +20,43 @@ export default function Card({
   link,
   className,
 }: Readonly<CardProps>): JSX.Element {
-  let cardElement = (
-    <MUICard className="flex m-3 justify-center">
-      <CardContent>
-        <Box className="flex flex-col">
-          {(!!title || !!icon) && (
-            <Typography component="div" variant="h5">
-              {!!icon && icon} {!!title && title}
-            </Typography>
-          )}
-          {!!description && (
-            <Typography
-              variant="subtitle1"
-              color="text.secondary"
-              component="div"
-              className="flex justify-between pt-1"
-            >
-              {description}
-            </Typography>
-          )}
-        </Box>
-      </CardContent>
-    </MUICard>
+  const content = (
+    <CardContent sx={{ p: 3 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {(!!title || !!icon) && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            {!!icon && (
+              <Box sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', fontSize: 28 }}>
+                {icon}
+              </Box>
+            )}
+            {!!title && (
+              <Typography component="div" variant="h6" fontWeight={600}>
+                {title}
+              </Typography>
+            )}
+          </Box>
+        )}
+        {!!description && (
+          <Typography variant="body2" color="text.secondary" component="div">
+            {description}
+          </Typography>
+        )}
+      </Box>
+    </CardContent>
   );
 
-  if (link) {
-    cardElement = (
-      <Link href={link} key={link} className="no-underline">
-        {cardElement}
-      </Link>
-    );
-  }
+  let cardElement = (
+    <MUICard sx={{ m: 1.5 }}>
+      {link ? (
+        <CardActionArea component={Link} href={link}>
+          {content}
+        </CardActionArea>
+      ) : (
+        content
+      )}
+    </MUICard>
+  );
 
   if (className) {
     cardElement = <Box className={className}>{cardElement}</Box>;

--- a/components/layout/AuthButton.tsx
+++ b/components/layout/AuthButton.tsx
@@ -1,8 +1,9 @@
 import { createClient } from '@/utils/supabase/server';
+import Button from '@mui/material/Button';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
-import UserMenu from './UserMenu/UserMenu';
 import { redirect } from 'next/navigation';
+import UserMenu from './UserMenu/UserMenu';
 
 export default async function AuthButton() {
   const cookieStore = cookies();
@@ -22,15 +23,16 @@ export default async function AuthButton() {
   };
 
   return user ? (
-    <div className="flex items-center gap-4 text-sm">
-      <UserMenu user={user} signOut={signOut} />
-    </div>
+    <UserMenu user={user} signOut={signOut} />
   ) : (
-    <Link
+    <Button
+      component={Link}
       href="/login"
-      className="py-2 px-3 flex rounded-md no-underline bg-btn-background hover:bg-btn-background-hover"
+      variant="outlined"
+      size="small"
+      sx={{ color: 'inherit', borderColor: 'rgba(255,255,255,0.5)', '&:hover': { borderColor: 'white', backgroundColor: 'rgba(255,255,255,0.08)' } }}
     >
       Login
-    </Link>
+    </Button>
   );
 }

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,29 +1,28 @@
 import GitHubIcon from '@mui/icons-material/GitHub';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
 
 export default function Footer() {
   return (
-    <footer className="w-full flex justify-center border-t border-t-foreground/10 h-16">
-      <div className="w-full max-w-4xl flex justify-between items-center p-3 text-xs">
-        <div>
+    <footer className="w-full flex justify-center border-t h-16">
+      <div className="w-full max-w-4xl flex justify-between items-center p-3">
+        <Typography variant="caption" color="text.secondary">
           A{' '}
-          <a
-            href="https://joshglazer.com"
-            target="_blank"
-            className="font-bold hover:underline"
-            rel="noreferrer"
-          >
+          <Link href="https://joshglazer.com" target="_blank" rel="noreferrer" underline="hover" color="inherit" fontWeight={600}>
             Josh Glazer
-          </a>{' '}
+          </Link>{' '}
           Project
-        </div>
-        <a
+        </Typography>
+        <Link
           href="https://github.com/joshglazer/band-manager"
           target="_blank"
-          className="font-bold hover:underline"
           rel="noreferrer"
+          underline="hover"
+          color="text.secondary"
+          sx={{ display: 'flex', alignItems: 'center', gap: 0.5, fontSize: '0.75rem', fontWeight: 600 }}
         >
-          <GitHubIcon /> Source Code On Github
-        </a>
+          <GitHubIcon sx={{ fontSize: 16 }} /> Source Code
+        </Link>
       </div>
     </footer>
   );

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,4 +1,6 @@
+import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Link from 'next/link';
@@ -7,18 +9,19 @@ import AuthButton from './AuthButton';
 
 export default function Header() {
   return (
-    <AppBar position="static">
-      <Toolbar>
-        <>
-          <Typography variant="h5" component="h1" className="flex-grow">
-            <Link href="/" className="text-inherit no-underline">
+    <AppBar position="static" sx={{ width: '100%' }}>
+      <Toolbar sx={{ maxWidth: '64rem', width: '100%', mx: 'auto', px: { xs: 2, sm: 3 } }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
+          <Link href="/" className="no-underline" style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'inherit' }}>
+            <MusicNoteIcon sx={{ fontSize: 26 }} />
+            <Typography variant="h6" component="h1" sx={{ fontWeight: 700, letterSpacing: '-0.02em' }}>
               Band Manager
-            </Link>
-          </Typography>
-          <Suspense>
-            <AuthButton />
-          </Suspense>
-        </>
+            </Typography>
+          </Link>
+        </Box>
+        <Suspense>
+          <AuthButton />
+        </Suspense>
       </Toolbar>
     </AppBar>
   );


### PR DESCRIPTION
Introduces a custom crimson/red MUI theme (stage energy, rock and roll vibe) that properly supports system dark mode via useMediaQuery. Fixes numerous layout issues across the app that were left over from the initial unstyled MUI setup.

Theme changes:
- New ThemeRegistry client component with dark/light mode detection
- Deep crimson primary palette: near-black dark bg, warm off-white text
- Custom component overrides: AppBar, Card, Table, Button, Avatar, etc.
- CssBaseline now owns body background/color (removed conflicting Tailwind body styles)
- Updated CSS custom properties to match new palette

Layout improvements:
- Login/Signup: forms centered in a card panel with heading and toggle link
- Home page: hero section with bold headline and Log in / Sign up CTA buttons
- Band layout: band name styled as h4 Typography with Divider separator
- Band create page: proper heading and subtitle
- Bands list: member/song counts replaced with Chip components, hr removed
- Songs/Setlists: hr tags removed, Link-wrapping-Button pattern fixed
- Header: music note icon, maxWidth-aligned toolbar, MUI Button for Login
- Footer: MUI Link/Typography for consistent theming
- Card: icons colored with primary.main, CardActionArea for clickable cards