### PR TITLE
feat(songs): add manual song creation

### DIFF
--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -2,6 +2,7 @@
 
 import Loading from '@/components/design/Loading';
 import Table, { TableProps, TablePropsDataType, TableRow } from '@/components/design/Table';
+import AddSongModal from '@/components/modals/AddSongModal';
 import SongCommentsModal from '@/components/modals/SongCommentsModal';
 import useSongs, { SongsComposite } from '@/hooks/useSongs';
 import Box from '@mui/material/Box';
@@ -25,7 +26,7 @@ function formatComments(value: TablePropsDataType | null, row: TableRow) {
 export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
   const { bandId } = params;
 
-  const { data: songs, isLoading } = useSongs({ bandId });
+  const { data: songs, isLoading, mutate } = useSongs({ bandId });
 
   if (isLoading) {
     return <Loading />;
@@ -78,7 +79,8 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
   return (
     <>
       {pageContent}
-      <Box sx={{ mt: 3 }}>
+      <Box sx={{ mt: 3, display: 'flex', gap: 2 }}>
+        <AddSongModal bandId={+bandId} onSuccess={mutate} />
         <Button
           component={Link}
           href={`/band/${bandId}/songs/spotify-import`}

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -1,0 +1,73 @@
+import { createClient } from '@/utils/supabase/client';
+import { useMemo, useState } from 'react';
+import { FieldValues } from 'react-hook-form';
+import Form, { FormField } from '../design/Form';
+
+interface AddSongFormProps {
+  bandId: number;
+  onSuccess?: () => void;
+}
+
+function parseDurationToMs(value: string): number | null {
+  const match = value.trim().match(/^(\d+):([0-5]\d)$/);
+  if (!match) return null;
+  const minutes = parseInt(match[1], 10);
+  const seconds = parseInt(match[2], 10);
+  return (minutes * 60 + seconds) * 1000;
+}
+
+export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormProps>) {
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const supabase = createClient();
+
+  const formFields: FormField[] = useMemo(
+    () => [
+      {
+        fieldType: 'text' as FormField['fieldType'],
+        name: 'name',
+        label: 'Song Name',
+        fullWidth: true,
+        required: true,
+      },
+      {
+        fieldType: 'text' as FormField['fieldType'],
+        name: 'artist',
+        label: 'Artist',
+        fullWidth: true,
+      },
+      {
+        fieldType: 'text' as FormField['fieldType'],
+        name: 'duration',
+        label: 'Duration (m:ss)',
+        placeholder: 'e.g. 3:45',
+        fullWidth: true,
+      },
+    ],
+    []
+  );
+
+  async function handleSuccess(data: FieldValues) {
+    setErrorMessage('');
+
+    const duration = data.duration ? parseDurationToMs(data.duration) : null;
+    if (data.duration && duration === null) {
+      setErrorMessage('Invalid duration format. Use m:ss (e.g. 3:45).');
+      return;
+    }
+
+    const { error } = await supabase.from('songs').insert({
+      name: data.name,
+      artist: data.artist || null,
+      duration,
+      band_id: bandId,
+    });
+
+    if (error) {
+      setErrorMessage(error.message);
+    } else {
+      onSuccess?.();
+    }
+  }
+
+  return <Form onSuccess={handleSuccess} formFields={formFields} errorMessage={errorMessage} saveButtonLabel="Add Song" />;
+}

--- a/components/modals/AddSongModal.tsx
+++ b/components/modals/AddSongModal.tsx
@@ -1,0 +1,34 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import { useState } from 'react';
+import AddSongForm from '../forms/AddSongForm';
+
+interface AddSongModalProps {
+  bandId: number;
+  onSuccess?: () => void;
+}
+
+export default function AddSongModal({ bandId, onSuccess }: Readonly<AddSongModalProps>) {
+  const [open, setOpen] = useState(false);
+
+  function handleSuccess() {
+    setOpen(false);
+    onSuccess?.();
+  }
+
+  return (
+    <>
+      <Button variant="contained" onClick={() => setOpen(true)}>
+        Add Song
+      </Button>
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>Add Song</DialogTitle>
+        <DialogContent className="pt-3">
+          <AddSongForm bandId={bandId} onSuccess={handleSuccess} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/hooks/useSongs.ts
+++ b/hooks/useSongs.ts
@@ -19,6 +19,7 @@ interface UseSongsResult {
   data?: SongsComposite[] | null;
   isLoading: boolean;
   error?: PostgrestError;
+  mutate: () => void;
 }
 
 export default function useSongs({ bandId }: UseSongsProps): UseSongsResult {
@@ -29,10 +30,10 @@ export default function useSongs({ bandId }: UseSongsProps): UseSongsResult {
     [bandId, supabase]
   );
 
-  const { data, isLoading, error } = useQuery<SongsComposite[]>(query, {
+  const { data, isLoading, error, mutate } = useQuery<SongsComposite[]>(query, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
   });
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, mutate };
 }


### PR DESCRIPTION
## Summary

- Adds an **Add Song** button to the Manage Songs page alongside the existing Spotify import button
- Clicking it opens a modal form with fields for Song Name (required), Artist (optional), and Duration in \`m:ss\` format (optional)
- After a successful save, the song list refreshes immediately via SWR \`mutate\` — no page reload needed
- Useful for songs not available on Spotify

## Changes

- \`components/forms/AddSongForm.tsx\` — new form component; parses \`m:ss\` duration to milliseconds before inserting into Supabase
- \`components/modals/AddSongModal.tsx\` — modal wrapper that closes on successful submission
- \`hooks/useSongs.ts\` — exposes \`mutate\` from the SWR query so the list can be refreshed after adding
- \`app/band/[bandId]/songs/page.tsx\` — wires up the new modal with \`mutate\` as the success callback

## Test plan

- [ ] Navigate to a band's Manage Songs page
- [ ] Click **Add Song** and verify the modal opens
- [ ] Submit with only a name — song should appear in the list
- [ ] Submit with name, artist, and duration (e.g. \`3:45\`) — verify all fields display correctly
- [ ] Submit with an invalid duration format — verify error message appears
- [ ] Verify the Spotify import button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)