### PR TITLE
Add edit song functionality

### DIFF
--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -3,6 +3,7 @@
 import Loading from '@/components/design/Loading';
 import Table, { TableProps, TablePropsDataType, TableRow } from '@/components/design/Table';
 import AddSongModal from '@/components/modals/AddSongModal';
+import EditSongModal from '@/components/modals/EditSongModal';
 import SongCommentsModal from '@/components/modals/SongCommentsModal';
 import useSongs, { SongsComposite } from '@/hooks/useSongs';
 import Box from '@mui/material/Box';
@@ -27,6 +28,10 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
   const { bandId } = params;
 
   const { data: songs, isLoading, mutate } = useSongs({ bandId });
+
+  function formatActions(_value: TablePropsDataType | null, row: TableRow) {
+    return <EditSongModal song={row as unknown as SongsComposite} onSuccess={mutate} />;
+  }
 
   if (isLoading) {
     return <Loading />;
@@ -67,6 +72,12 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
           dataKey: 'commentsCount',
           className: 'whitespace-nowrap',
           dataFormatter: formatComments,
+        },
+        {
+          name: '',
+          dataKey: 'id',
+          dataFormatter: formatActions,
+          className: 'whitespace-nowrap',
         },
       ],
       rows: songsForTable,

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -1,0 +1,100 @@
+import { Tables } from '@/types/supabase';
+import { createClient } from '@/utils/supabase/client';
+import { useMemo, useState } from 'react';
+import { FieldValues } from 'react-hook-form';
+import Form, { FormField } from '../design/Form';
+
+interface EditSongFormProps {
+  song: Tables<'songs'>;
+  onSuccess?: () => void;
+}
+
+function parseDurationToMs(value: string): number | null {
+  const match = value.trim().match(/^(\d+):([0-5]\d)$/);
+  if (!match) return null;
+  const minutes = parseInt(match[1], 10);
+  const seconds = parseInt(match[2], 10);
+  return (minutes * 60 + seconds) * 1000;
+}
+
+function formatMsToDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormProps>) {
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const supabase = createClient();
+
+  const formFields: FormField[] = useMemo(
+    () => [
+      {
+        fieldType: 'text' as FormField['fieldType'],
+        name: 'name',
+        label: 'Song Name',
+        fullWidth: true,
+        required: true,
+      },
+      {
+        fieldType: 'text' as FormField['fieldType'],
+        name: 'artist',
+        label: 'Artist',
+        fullWidth: true,
+      },
+      {
+        fieldType: 'text' as FormField['fieldType'],
+        name: 'duration',
+        label: 'Duration (m:ss)',
+        placeholder: 'e.g. 3:45',
+        fullWidth: true,
+      },
+    ],
+    []
+  );
+
+  const defaultValues = useMemo(
+    () => ({
+      name: song.name ?? '',
+      artist: song.artist ?? '',
+      duration: song.duration ? formatMsToDuration(song.duration) : '',
+    }),
+    [song]
+  );
+
+  async function handleSuccess(data: FieldValues) {
+    setErrorMessage('');
+
+    const duration = data.duration ? parseDurationToMs(data.duration) : null;
+    if (data.duration && duration === null) {
+      setErrorMessage('Invalid duration format. Use m:ss (e.g. 3:45).');
+      return;
+    }
+
+    const { error } = await supabase
+      .from('songs')
+      .update({
+        name: data.name,
+        artist: data.artist || null,
+        duration,
+      })
+      .eq('id', song.id);
+
+    if (error) {
+      setErrorMessage(error.message);
+    } else {
+      onSuccess?.();
+    }
+  }
+
+  return (
+    <Form
+      onSuccess={handleSuccess}
+      formFields={formFields}
+      defaultValues={defaultValues}
+      errorMessage={errorMessage}
+      saveButtonLabel="Save Changes"
+    />
+  );
+}

--- a/components/modals/EditSongModal.tsx
+++ b/components/modals/EditSongModal.tsx
@@ -1,0 +1,36 @@
+import { Tables } from '@/types/supabase';
+import EditIcon from '@mui/icons-material/Edit';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
+import { useState } from 'react';
+import EditSongForm from '../forms/EditSongForm';
+
+interface EditSongModalProps {
+  song: Tables<'songs'>;
+  onSuccess?: () => void;
+}
+
+export default function EditSongModal({ song, onSuccess }: Readonly<EditSongModalProps>) {
+  const [open, setOpen] = useState(false);
+
+  function handleSuccess() {
+    setOpen(false);
+    onSuccess?.();
+  }
+
+  return (
+    <>
+      <IconButton aria-label="Edit song" size="small" onClick={() => setOpen(true)}>
+        <EditIcon fontSize="small" />
+      </IconButton>
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>Edit Song</DialogTitle>
+        <DialogContent className="pt-3">
+          <EditSongForm song={song} onSuccess={handleSuccess} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
Adds an edit button to each row in the songs table that opens a pre-populated modal form, allowing users to update a song's name, artist, and duration.

https://claude.ai/code/session_01NRT3ZZq5yK9PAFR4vDprs3