### PR TITLE
Add breadcrumb navigation to band layout

### DIFF
--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Loading from '@/components/design/Loading';
+import BandBreadcrumbs from '@/components/layout/BandBreadcrumbs';
 import useBand from '@/hooks/useBand';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
@@ -26,6 +27,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
     return (
       <>
         <Box sx={{ pt: 3, pb: 2 }}>
+          <BandBreadcrumbs bandId={bandId} bandName={band.name} />
           <Typography variant="h4" fontWeight={700} color="text.primary">
             {band.name}
           </Typography>

--- a/components/layout/BandBreadcrumbs.tsx
+++ b/components/layout/BandBreadcrumbs.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import MuiBreadcrumbs from '@mui/material/Breadcrumbs';
+import MuiLink from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import NextLink from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface BandBreadcrumbsProps {
+  bandId: number;
+  bandName: string;
+}
+
+const SEGMENT_LABELS: Record<string, string> = {
+  members: 'Members',
+  songs: 'Songs',
+  setlists: 'Setlists',
+  create: 'Create Setlist',
+  edit: 'Edit Setlist',
+  'spotify-import': 'Import from Spotify',
+};
+
+export default function BandBreadcrumbs({ bandId, bandName }: BandBreadcrumbsProps) {
+  const pathname = usePathname();
+
+  const basePath = `/band/${bandId}`;
+  const rest = pathname.replace(basePath, '').split('/').filter(Boolean);
+  const isBandDashboard = rest.length === 0;
+
+  const breadcrumbs: { label: string; href: string | null }[] = [
+    { label: 'Home', href: '/' },
+  ];
+
+  if (isBandDashboard) {
+    breadcrumbs.push({ label: bandName, href: null });
+  } else {
+    breadcrumbs.push({ label: bandName, href: basePath });
+
+    let cumulativePath = basePath;
+    const displayItems: { label: string; href: string | null }[] = [];
+
+    for (const segment of rest) {
+      cumulativePath += `/${segment}`;
+      if (!isNaN(Number(segment))) continue;
+      displayItems.push({ label: SEGMENT_LABELS[segment] ?? segment, href: cumulativePath });
+    }
+
+    if (displayItems.length > 0) {
+      displayItems[displayItems.length - 1].href = null;
+    }
+
+    breadcrumbs.push(...displayItems);
+  }
+
+  return (
+    <MuiBreadcrumbs sx={{ mb: 2 }}>
+      {breadcrumbs.map((crumb, index) =>
+        crumb.href ? (
+          <MuiLink
+            key={index}
+            component={NextLink}
+            href={crumb.href}
+            underline="hover"
+            color="inherit"
+            variant="body2"
+          >
+            {crumb.label}
+          </MuiLink>
+        ) : (
+          <Typography key={index} color="text.primary" variant="body2">
+            {crumb.label}
+          </Typography>
+        )
+      )}
+    </MuiBreadcrumbs>
+  );
+}


### PR DESCRIPTION
Adds a BandBreadcrumbs component that renders MUI Breadcrumbs above the
band name heading for all band routes. Shows Home > Band Name > Page,
with every crumb except the current page linked. Handles nested routes
like songs/spotify-import and setlists/[id]/edit by filtering out numeric
dynamic segments from display.

https://claude.ai/code/session_01XJyd9f1TufnyBBWMjs6tiN