### PR TITLE
Add search and sorting to the manage songs table

### DIFF
--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -8,8 +8,10 @@ import SongCommentsModal from '@/components/modals/SongCommentsModal';
 import useSongs, { SongsComposite } from '@/hooks/useSongs';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
 import Link from 'next/link';
 import prettyMilliseconds from 'pretty-ms';
+import { useState } from 'react';
 import { BandRouteProps } from '../types';
 
 function formatDuration(value?: TablePropsDataType | null) {
@@ -28,6 +30,19 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
   const { bandId } = params;
 
   const { data: songs, isLoading, mutate } = useSongs({ bandId });
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortConfig, setSortConfig] = useState<{ key: string; direction: 'asc' | 'desc' } | null>(
+    null
+  );
+
+  function handleSort(key: string) {
+    setSortConfig((prev) => {
+      if (prev?.key === key) {
+        return { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      }
+      return { key, direction: 'asc' };
+    });
+  }
 
   function formatActions(_value: TablePropsDataType | null, row: TableRow) {
     return <EditSongModal song={row as unknown as SongsComposite} onSuccess={mutate} />;
@@ -53,13 +68,34 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
   let pageContent: JSX.Element;
 
   if (songs?.length) {
-    const songsForTable = songs.map((song) => ({
+    const allSongs = songs.map((song) => ({
       id: song.id,
       name: song.name,
       artist: song.artist,
       duration: song.duration,
       commentsCount: song.song_comments[0].count,
     }));
+
+    const q = searchQuery.toLowerCase();
+    const filteredSongs = q
+      ? allSongs.filter(
+          (song) =>
+            song.name?.toString().toLowerCase().includes(q) ||
+            song.artist?.toString().toLowerCase().includes(q)
+        )
+      : allSongs;
+
+    const songsForTable = sortConfig
+      ? [...filteredSongs].sort((a, b) => {
+          const aVal = a[sortConfig.key as keyof typeof a] ?? '';
+          const bVal = b[sortConfig.key as keyof typeof b] ?? '';
+          const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+          return sortConfig.direction === 'asc' ? cmp : -cmp;
+        })
+      : filteredSongs;
+
+    const sortDir = (key: string) =>
+      sortConfig?.key === key ? sortConfig.direction : undefined;
 
     const songsTableData: TableProps = {
       ariaLabel: 'Table of Songs',
@@ -69,16 +105,25 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
           dataKey: 'name',
           isHeader: true,
           headerDataKey: 'id',
+          sortable: true,
+          sortDirection: sortDir('name'),
+          onSort: () => handleSort('name'),
         },
         {
           name: 'Artist',
           dataKey: 'artist',
+          sortable: true,
+          sortDirection: sortDir('artist'),
+          onSort: () => handleSort('artist'),
         },
         {
           name: 'Length',
           dataKey: 'duration',
           dataFormatter: formatDuration,
           className: 'whitespace-nowrap',
+          sortable: true,
+          sortDirection: sortDir('duration'),
+          onSort: () => handleSort('duration'),
         },
         {
           name: 'Comments',
@@ -108,6 +153,15 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
 
   return (
     <>
+      <Box sx={{ mb: 2 }}>
+        <TextField
+          label="Search songs"
+          size="small"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Filter by name or artist"
+        />
+      </Box>
       {pageContent}
       <Box sx={{ mt: 3, display: 'flex', gap: 2 }}>
         <AddSongModal bandId={+bandId} onSuccess={mutate} />

--- a/components/design/Table.tsx
+++ b/components/design/Table.tsx
@@ -6,6 +6,7 @@ import TableCell, { TableCellProps } from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
 
 type TablePropsDataType = string | number | null | undefined;
 
@@ -22,6 +23,9 @@ interface TableProps {
     isHeader?: boolean;
     headerDataKey?: TablePropsDataType;
     className?: string;
+    sortable?: boolean;
+    sortDirection?: 'asc' | 'desc';
+    onSort?: () => void;
   }[];
   rows: TableRow[];
 }
@@ -44,8 +48,20 @@ export default function Table({ ariaLabel, columns, rows }: Readonly<TableProps>
       <MUITable aria-label="Table of Songs">
         <TableHead>
           <TableRow>
-            {columns.map(({ name }) => (
-              <TableCell key={name}>{name}</TableCell>
+            {columns.map(({ name, sortable, sortDirection, onSort }) => (
+              <TableCell key={name}>
+                {sortable ? (
+                  <TableSortLabel
+                    active={sortDirection !== undefined}
+                    direction={sortDirection ?? 'asc'}
+                    onClick={onSort}
+                  >
+                    {name}
+                  </TableSortLabel>
+                ) : (
+                  name
+                )}
+              </TableCell>
             ))}
           </TableRow>
         </TableHead>


### PR DESCRIPTION
- Search TextField filters songs by name or artist (case-insensitive)
- Clickable sort labels on Name, Artist, and Length columns (toggle asc/desc)
- Table.tsx extended with sortable/sortDirection/onSort column props using MUI TableSortLabel

https://claude.ai/code/session_014wfYU4vgMev3wMVU89hm9w