### PR TITLE
Improve practice screen: sorting, filtering, auto-save, toast feedback

### DIFF
--- a/app/band/[bandId]/practice/page.tsx
+++ b/app/band/[bandId]/practice/page.tsx
@@ -4,33 +4,40 @@ import Loading from '@/components/design/Loading';
 import usePracticeProgress from '@/hooks/usePracticeProgress';
 import useSongs from '@/hooks/useSongs';
 import { createClient } from '@/utils/supabase/client';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import { LoadingButton } from '@mui/lab';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
 import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { BandRouteProps } from '../types';
 
 type PracticeStatus = 'not_ready' | 'passable' | 'ready';
-type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+type SortColumn = 'name' | 'status' | 'notes';
+type SortDir = 'asc' | 'desc';
+
+const STATUS_ORDER: Record<PracticeStatus, number> = { not_ready: 0, passable: 1, ready: 2 };
 
 interface SongProgress {
   id?: number;
   status: PracticeStatus;
   notes: string;
-  saveState: SaveState;
-  errorMessage?: string;
+}
+
+interface ToastState {
+  open: boolean;
+  severity: 'success' | 'error';
+  message: string;
 }
 
 export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
@@ -53,33 +60,37 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
         id: pp?.id,
         status: (pp?.status as PracticeStatus) ?? 'not_ready',
         notes: pp?.notes ?? '',
-        saveState: 'idle',
       };
     }
     return map;
   }, [songs, practiceRows]);
 
   const [progress, setProgress] = useState<Record<number, SongProgress>>({});
+  const [sortConfig, setSortConfig] = useState<{ key: SortColumn; direction: SortDir } | null>(
+    null
+  );
+  const [statusFilter, setStatusFilter] = useState<PracticeStatus | 'all'>('all');
+  const [toast, setToast] = useState<ToastState>({ open: false, severity: 'success', message: '' });
+  const debounceRefs = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
 
   useEffect(() => {
     setProgress(initialProgress);
   }, [initialProgress]);
 
-  async function save(songId: number, status: PracticeStatus, notes: string) {
-    setProgress((prev) => ({
-      ...prev,
-      [songId]: { ...prev[songId], saveState: 'saving' },
-    }));
+  useEffect(() => {
+    const refs = debounceRefs.current;
+    return () => {
+      Object.values(refs).forEach(clearTimeout);
+    };
+  }, []);
 
+  async function save(songId: number, status: PracticeStatus, notes: string) {
     const {
       data: { user },
     } = await supabase.auth.getUser();
 
     if (!user) {
-      setProgress((prev) => ({
-        ...prev,
-        [songId]: { ...prev[songId], saveState: 'error', errorMessage: 'Not logged in.' },
-      }));
+      setToast({ open: true, severity: 'error', message: 'Not logged in.' });
       return;
     }
 
@@ -100,37 +111,42 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
       .single();
 
     if (error) {
-      setProgress((prev) => ({
-        ...prev,
-        [songId]: { ...prev[songId], saveState: 'error', errorMessage: error.message },
-      }));
+      setToast({ open: true, severity: 'error', message: error.message });
     } else {
       setProgress((prev) => ({
         ...prev,
-        [songId]: { ...prev[songId], id: data?.id, saveState: 'saved', errorMessage: undefined },
+        [songId]: { ...prev[songId], id: data?.id },
       }));
+      setToast({ open: true, severity: 'success', message: 'Changes saved' });
     }
   }
 
   function handleStatusChange(songId: number, status: PracticeStatus) {
-    setProgress((prev) => ({
-      ...prev,
-      [songId]: { ...prev[songId], status, saveState: 'idle' },
-    }));
+    setProgress((prev) => {
+      const updated = { ...prev, [songId]: { ...prev[songId], status } };
+      save(songId, status, updated[songId].notes);
+      return updated;
+    });
   }
 
   function handleNotesChange(songId: number, notes: string) {
-    setProgress((prev) => ({
-      ...prev,
-      [songId]: { ...prev[songId], notes, saveState: 'idle' },
-    }));
+    setProgress((prev) => {
+      const updated = { ...prev, [songId]: { ...prev[songId], notes } };
+      if (debounceRefs.current[songId]) clearTimeout(debounceRefs.current[songId]);
+      debounceRefs.current[songId] = setTimeout(() => {
+        save(songId, updated[songId].status, notes);
+      }, 700);
+      return updated;
+    });
   }
 
-  function handleSave(songId: number) {
-    const p = progress[songId];
-    if (p) {
-      save(songId, p.status, p.notes);
-    }
+  function handleSort(key: SortColumn) {
+    setSortConfig((prev) => {
+      if (prev?.key === key) {
+        return { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      }
+      return { key, direction: 'asc' };
+    });
   }
 
   if (isLoading) {
@@ -141,25 +157,94 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
     return <Typography>No songs have been added to this band yet.</Typography>;
   }
 
+  const rows = songs.map((song) => ({
+    song,
+    p: progress[song.id] ?? { status: 'not_ready' as PracticeStatus, notes: '' },
+  }));
+
+  const filtered =
+    statusFilter === 'all' ? rows : rows.filter((r) => r.p.status === statusFilter);
+
+  const sorted = sortConfig
+    ? [...filtered].sort((a, b) => {
+        let cmp = 0;
+        if (sortConfig.key === 'name') {
+          const aName = a.song.name ?? '';
+          const bName = b.song.name ?? '';
+          cmp = aName < bName ? -1 : aName > bName ? 1 : 0;
+        } else if (sortConfig.key === 'status') {
+          cmp = STATUS_ORDER[a.p.status] - STATUS_ORDER[b.p.status];
+        } else if (sortConfig.key === 'notes') {
+          const aN = a.p.notes ?? '';
+          const bN = b.p.notes ?? '';
+          cmp = aN < bN ? -1 : aN > bN ? 1 : 0;
+        }
+        return sortConfig.direction === 'asc' ? cmp : -cmp;
+      })
+    : filtered;
+
+  const sortDir = (key: SortColumn) =>
+    sortConfig?.key === key ? sortConfig.direction : undefined;
+
   return (
-    <TableContainer component={Paper}>
-      <Table aria-label="Practice progress">
-        <TableHead>
-          <TableRow>
-            <TableCell>Song</TableCell>
-            <TableCell>Your Status</TableCell>
-            <TableCell>Notes</TableCell>
-            <TableCell />
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {songs.map((song) => {
-            const p = progress[song.id] ?? {
-              status: 'not_ready' as PracticeStatus,
-              notes: '',
-              saveState: 'idle' as SaveState,
-            };
-            return (
+    <>
+      <Box sx={{ mb: 2, display: 'flex', gap: 1.5, alignItems: 'center', flexWrap: 'wrap' }}>
+        <Typography variant="body2" color="text.secondary">
+          Filter:
+        </Typography>
+        <ToggleButtonGroup
+          value={statusFilter}
+          exclusive
+          onChange={(_, value) => value && setStatusFilter(value)}
+          size="small"
+        >
+          <ToggleButton value="all">All</ToggleButton>
+          <ToggleButton value="not_ready" color="error">
+            Not Ready
+          </ToggleButton>
+          <ToggleButton value="passable" color="warning">
+            Passable
+          </ToggleButton>
+          <ToggleButton value="ready" color="success">
+            Ready
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+      <TableContainer component={Paper}>
+        <Table aria-label="Practice progress">
+          <TableHead>
+            <TableRow>
+              <TableCell>
+                <TableSortLabel
+                  active={sortConfig?.key === 'name'}
+                  direction={sortDir('name') ?? 'asc'}
+                  onClick={() => handleSort('name')}
+                >
+                  Song
+                </TableSortLabel>
+              </TableCell>
+              <TableCell>
+                <TableSortLabel
+                  active={sortConfig?.key === 'status'}
+                  direction={sortDir('status') ?? 'asc'}
+                  onClick={() => handleSort('status')}
+                >
+                  Your Status
+                </TableSortLabel>
+              </TableCell>
+              <TableCell>
+                <TableSortLabel
+                  active={sortConfig?.key === 'notes'}
+                  direction={sortDir('notes') ?? 'asc'}
+                  onClick={() => handleSort('notes')}
+                >
+                  Notes
+                </TableSortLabel>
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sorted.map(({ song, p }) => (
               <TableRow key={song.id}>
                 <TableCell component="th" scope="row">
                   <Typography fontWeight={600}>{song.name}</Typography>
@@ -200,31 +285,26 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
                     maxRows={3}
                   />
                 </TableCell>
-                <TableCell sx={{ whiteSpace: 'nowrap' }}>
-                  {p.saveState === 'saved' && (
-                    <Tooltip title="Saved">
-                      <CheckCircleOutlineIcon color="success" sx={{ mr: 1, verticalAlign: 'middle' }} />
-                    </Tooltip>
-                  )}
-                  {p.saveState === 'error' && (
-                    <Tooltip title={p.errorMessage ?? 'Save failed'}>
-                      <ErrorOutlineIcon color="error" sx={{ mr: 1, verticalAlign: 'middle' }} />
-                    </Tooltip>
-                  )}
-                  <LoadingButton
-                    variant="contained"
-                    size="small"
-                    loading={p.saveState === 'saving'}
-                    onClick={() => handleSave(song.id)}
-                  >
-                    Save
-                  </LoadingButton>
-                </TableCell>
               </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </TableContainer>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={2500}
+        onClose={() => setToast((prev) => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={toast.severity}
+          onClose={() => setToast((prev) => ({ ...prev, open: false }))}
+          variant="filled"
+          sx={{ width: '100%' }}
+        >
+          {toast.message}
+        </Alert>
+      </Snackbar>
+    </>
   );
 }

--- a/components/layout/BandBreadcrumbs.tsx
+++ b/components/layout/BandBreadcrumbs.tsx
@@ -18,6 +18,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   create: 'Create Setlist',
   edit: 'Edit Setlist',
   'spotify-import': 'Import from Spotify',
+  practice: 'Practice',
 };
 
 export default function BandBreadcrumbs({ bandId, bandName }: BandBreadcrumbsProps) {
@@ -27,9 +28,7 @@ export default function BandBreadcrumbs({ bandId, bandName }: BandBreadcrumbsPro
   const rest = pathname.replace(basePath, '').split('/').filter(Boolean);
   const isBandDashboard = rest.length === 0;
 
-  const breadcrumbs: { label: string; href: string | null }[] = [
-    { label: 'Home', href: '/' },
-  ];
+  const breadcrumbs: { label: string; href: string | null }[] = [{ label: 'Home', href: '/' }];
 
   if (isBandDashboard) {
     breadcrumbs.push({ label: bandName, href: null });


### PR DESCRIPTION
## Summary

- All three columns (Song, Status, Notes) are sortable via clickable `TableSortLabel` headers
- Status filter bar (All / Not Ready / Passable / Ready) above the table lets users focus on specific readiness levels
- Status changes trigger an immediate save; notes changes debounce 700ms before saving — no manual Save button needed
- Replaced the per-row checkmark/error icon and Save button with a centered `Snackbar` toast showing success or error feedback

## Test plan

- [ ] Sort by Song, Status, and Notes — verify ascending/descending works correctly
- [ ] Filter by each status and confirm only matching rows appear; "All" shows everything
- [ ] Change a status toggle — confirm toast "Changes saved" appears without a button click
- [ ] Type in a notes field — confirm save fires ~700ms after the last keystroke (toast appears), not on every character
- [ ] Verify error path (e.g. sign out in another tab) shows an error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)