### PR TITLE
Add feature card variant to differentiate band dashboard from bands list

### DIFF
--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -45,7 +45,7 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
   const responsiveGridItems = useMemo(() => {
     return actions.map((action) => ({
       key: action.link,
-      content: <Card {...action} className={cardClassName} />,
+      content: <Card {...action} className={cardClassName} variant="feature" />,
     }));
   }, [actions]);
 

--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -10,7 +10,7 @@ import { BandRouteProps } from './types';
 export default function BandDashboardPage({ params }: Readonly<BandRouteProps>): JSX.Element {
   const { bandId } = params;
 
-  const actions: Required<Omit<CardProps, 'className'>>[] = useMemo(
+  const actions: Required<Omit<CardProps, 'className' | 'variant'>>[] = useMemo(
     () => [
       {
         title: 'Manage Members',

--- a/components/design/Card.tsx
+++ b/components/design/Card.tsx
@@ -11,6 +11,7 @@ interface CardProps {
   description?: string | JSX.Element | null;
   link?: string;
   className?: string;
+  variant?: 'default' | 'feature';
 }
 
 export default function Card({
@@ -19,8 +20,43 @@ export default function Card({
   icon,
   link,
   className,
+  variant = 'default',
 }: Readonly<CardProps>): JSX.Element {
-  const content = (
+  const isFeature = variant === 'feature';
+
+  const content = isFeature ? (
+    <CardContent sx={{ p: 4, textAlign: 'center' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+        {!!icon && (
+          <Box
+            sx={{
+              color: 'primary.main',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 48,
+              width: 80,
+              height: 80,
+              borderRadius: '50%',
+              bgcolor: 'action.hover',
+            }}
+          >
+            {icon}
+          </Box>
+        )}
+        {!!title && (
+          <Typography component="div" variant="h6" fontWeight={600}>
+            {title}
+          </Typography>
+        )}
+        {!!description && (
+          <Typography variant="body2" color="text.secondary" component="div">
+            {description}
+          </Typography>
+        )}
+      </Box>
+    </CardContent>
+  ) : (
     <CardContent sx={{ p: 3 }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
         {(!!title || !!icon) && (


### PR DESCRIPTION
The band dashboard sections (Members, Songs, Setlists, Practice) now use
a centered layout with a large circular icon, making them visually distinct
from the compact left-aligned band list cards on the home page.

https://claude.ai/code/session_014EQB82xj5TzcTF2L3ui8R9