### PR TITLE
Add Practice button on setlists page with pre-filled setlist filter

### DIFF
--- a/app/band/[bandId]/practice/page.tsx
+++ b/app/band/[bandId]/practice/page.tsx
@@ -26,6 +26,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { BandRouteProps } from '../types';
 
 type PracticeStatus = 'not_ready' | 'passable' | 'ready';
@@ -49,6 +50,8 @@ interface ToastState {
 export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
   const { bandId } = params;
   const supabase = createClient();
+  const searchParams = useSearchParams();
+  const setlistParam = searchParams.get('setlist');
 
   const { data: songs, isLoading: songsLoading } = useSongs({ bandId });
   const { data: practiceRows, isLoading: progressLoading } = usePracticeProgress({
@@ -77,7 +80,9 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
     null
   );
   const [statusFilter, setStatusFilter] = useState<PracticeStatus[]>([]);
-  const [setlistFilter, setSetlistFilter] = useState<number | ''>('');
+  const [setlistFilter, setSetlistFilter] = useState<number | ''>(
+    setlistParam ? +setlistParam : ''
+  );
   const [toast, setToast] = useState<ToastState>({ open: false, severity: 'success', message: '' });
   const debounceRefs = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
 

--- a/app/band/[bandId]/setlists/page.tsx
+++ b/app/band/[bandId]/setlists/page.tsx
@@ -36,12 +36,20 @@ export default function BandSetlistsPage({ params }: Readonly<BandRouteProps>) {
   const formatEditButton = useCallback(
     (setlistId: TablePropsDataType) => {
       return (
-        <Button
-          variant="outlined"
-          onClick={() => router.push(`/band/${bandId}/setlists/${setlistId}/edit`)}
-        >
-          Edit
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            variant="outlined"
+            onClick={() => router.push(`/band/${bandId}/practice?setlist=${setlistId}`)}
+          >
+            Practice
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() => router.push(`/band/${bandId}/setlists/${setlistId}/edit`)}
+          >
+            Edit
+          </Button>
+        </Box>
       );
     },
     [bandId, router]


### PR DESCRIPTION
## Summary
- Adds a **Practice** button to each row on the setlists page
- Clicking it navigates to the practice screen with `?setlist=<id>` in the URL
- The practice page reads that query param on mount and pre-selects the setlist in the filter dropdown

## Test plan
- [ ] Go to a band's setlists page — confirm each row now shows Practice + Edit buttons
- [ ] Click Practice on a setlist — confirm you land on the practice page with that setlist pre-selected in the filter
- [ ] Confirm the practice table shows only songs from that setlist, in setlist order
- [ ] Navigate directly to `/band/[id]/practice` (no query param) — confirm filter defaults to "None"

🤖 Generated with [Claude Code](https://claude.com/claude-code)