### PR TITLE
Add band archiving

### DIFF
--- a/app/api/bands/[bandId]/archive/route.ts
+++ b/app/api/bands/[bandId]/archive/route.ts
@@ -1,0 +1,44 @@
+import { createClient } from '@/utils/supabase/server';
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { bandId: string } }
+) {
+  const bandId = parseInt(params.bandId, 10);
+  if (!bandId) {
+    return NextResponse.json({ error: 'Invalid band ID' }, { status: 400 });
+  }
+
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: band, error: fetchError } = await supabase
+    .from('bands')
+    .select('archived_at')
+    .eq('id', bandId)
+    .maybeSingle();
+
+  if (fetchError || !band) {
+    return NextResponse.json({ error: 'Band not found' }, { status: 404 });
+  }
+
+  const archived_at = band.archived_at ? null : new Date().toISOString();
+
+  const { error: updateError } = await supabase
+    .from('bands')
+    .update({ archived_at })
+    .eq('id', bandId);
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ archived_at });
+}

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -33,7 +33,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
   if (band) {
     const isArchived = !!band.archived_at;
 
-    async function toggleArchive() {
+    const toggleArchive = async () => {
       setArchiving(true);
       try {
         await fetch(`/api/bands/${bandId}/archive`, { method: 'POST' });
@@ -41,7 +41,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
       } finally {
         setArchiving(false);
       }
-    }
+    };
 
     return (
       <>

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -3,10 +3,15 @@
 import Loading from '@/components/design/Loading';
 import BandBreadcrumbs from '@/components/layout/BandBreadcrumbs';
 import useBand from '@/hooks/useBand';
+import ArchiveIcon from '@mui/icons-material/Archive';
+import UnarchiveIcon from '@mui/icons-material/Unarchive';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import { ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import { ReactNode, useState } from 'react';
 import { BandRouteProps } from './types';
 
 interface ConsumerProps {
@@ -18,19 +23,51 @@ type BandLayoutProps = BandRouteProps & ConsumerProps;
 export default function BandLayout({ children, params }: BandLayoutProps) {
   const { bandId } = params;
   const { data: band, isLoading } = useBand({ bandId });
+  const [archiving, setArchiving] = useState(false);
+  const router = useRouter();
 
   if (isLoading) {
     return <Loading />;
   }
 
   if (band) {
+    const isArchived = !!band.archived_at;
+
+    async function toggleArchive() {
+      setArchiving(true);
+      try {
+        await fetch(`/api/bands/${bandId}/archive`, { method: 'POST' });
+        router.refresh();
+      } finally {
+        setArchiving(false);
+      }
+    }
+
     return (
       <>
         <Box sx={{ pt: 3, pb: 2 }}>
           <BandBreadcrumbs bandId={bandId} bandName={band.name} />
-          <Typography variant="h4" fontWeight={700} color="text.primary">
-            {band.name}
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+            <Typography variant="h4" fontWeight={700} color="text.primary">
+              {band.name}
+            </Typography>
+            {isArchived && (
+              <Chip label="Archived" size="small" color="default" variant="outlined" />
+            )}
+            <Box sx={{ ml: 'auto' }}>
+              <Button
+                size="small"
+                variant="text"
+                color="inherit"
+                startIcon={isArchived ? <UnarchiveIcon /> : <ArchiveIcon />}
+                onClick={toggleArchive}
+                disabled={archiving}
+                sx={{ color: 'text.secondary' }}
+              >
+                {isArchived ? 'Unarchive band' : 'Archive band'}
+              </Button>
+            </Box>
+          </Box>
           <Divider sx={{ mt: 2 }} />
         </Box>
         <Box>{children}</Box>

--- a/components/Bands.tsx
+++ b/components/Bands.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import useBands from '@/hooks/useBands';
+import ArchiveIcon from '@mui/icons-material/Archive';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
 import PeopleIcon from '@mui/icons-material/People';
+import UnarchiveIcon from '@mui/icons-material/Unarchive';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -10,17 +12,70 @@ import Grid from '@mui/material/Grid';
 import MuiLink from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import Link from 'next/link';
+import { useState } from 'react';
 import Card from './design/Card';
 import Loading from './design/Loading';
 
-export default function Bands() {
-  const { data, isLoading } = useBands();
+function BandList({ includeArchived }: { includeArchived: boolean }) {
+  const { data, isLoading } = useBands({ includeArchived });
 
   if (isLoading) {
     return <Loading />;
   }
 
   if (!data?.length) {
+    return (
+      <Box sx={{ py: 2 }}>
+        <Typography color="text.secondary">
+          {includeArchived ? 'No archived bands.' : 'No active bands.'}
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Grid container spacing={2} justifyContent="flex-start" alignItems="stretch">
+      {data.map(({ id, name, song_count, member_count }) => {
+        const bandCardDescription = (
+          <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
+            <Chip
+              icon={<PeopleIcon />}
+              label={`${member_count} member${member_count !== 1 ? 's' : ''}`}
+              size="small"
+              variant="outlined"
+            />
+            <Chip
+              icon={<LibraryMusicIcon />}
+              label={`${song_count} song${song_count !== 1 ? 's' : ''}`}
+              size="small"
+              variant="outlined"
+            />
+          </Box>
+        );
+
+        return (
+          <Card
+            key={id}
+            title={name}
+            description={bandCardDescription}
+            link={`/band/${id}`}
+            className="md:basis-1/3 sm:basis-1/2 basis-full"
+          />
+        );
+      })}
+    </Grid>
+  );
+}
+
+export default function Bands() {
+  const { data: activeBands, isLoading } = useBands();
+  const [showArchived, setShowArchived] = useState(false);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (!activeBands?.length && !showArchived) {
     return (
       <Box sx={{ py: 4 }}>
         <Typography color="text.secondary">
@@ -35,41 +90,29 @@ export default function Bands() {
 
   return (
     <>
-      <Grid container spacing={2} justifyContent="flex-start" alignItems="stretch">
-        {data.map(({ id, name, song_count, member_count }) => {
-          const bandCardDescription = (
-            <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
-              <Chip
-                icon={<PeopleIcon />}
-                label={`${member_count} member${member_count !== 1 ? 's' : ''}`}
-                size="small"
-                variant="outlined"
-              />
-              <Chip
-                icon={<LibraryMusicIcon />}
-                label={`${song_count} song${song_count !== 1 ? 's' : ''}`}
-                size="small"
-                variant="outlined"
-              />
-            </Box>
-          );
-
-          return (
-            <Card
-              key={id}
-              title={name}
-              description={bandCardDescription}
-              link={`/band/${id}`}
-              className="md:basis-1/3 sm:basis-1/2 basis-full"
-            />
-          );
-        })}
-      </Grid>
-      <Box sx={{ mt: 3 }}>
+      <BandList includeArchived={false} />
+      <Box sx={{ mt: 3, display: 'flex', gap: 2, flexWrap: 'wrap' }}>
         <Button component={Link} href="/band/create" variant="outlined">
           Add another band
         </Button>
+        <Button
+          variant="text"
+          color="inherit"
+          startIcon={showArchived ? <UnarchiveIcon /> : <ArchiveIcon />}
+          onClick={() => setShowArchived((prev) => !prev)}
+          sx={{ color: 'text.secondary' }}
+        >
+          {showArchived ? 'Hide archived bands' : 'View archived bands'}
+        </Button>
       </Box>
+      {showArchived && (
+        <Box sx={{ mt: 4 }}>
+          <Typography variant="h6" fontWeight={600} mb={2} color="text.secondary">
+            Archived Bands
+          </Typography>
+          <BandList includeArchived={true} />
+        </Box>
+      )}
     </>
   );
 }

--- a/hooks/useBand.ts
+++ b/hooks/useBand.ts
@@ -22,7 +22,7 @@ export default function useBand({ bandId }: UseBandProps): UseBandResult {
   const supabase = createClient();
 
   const query = useMemo(
-    () => supabase.from('bands').select().eq('id', bandId).maybeSingle(),
+    () => supabase.from('bands').select('id, name, created_at, archived_at').eq('id', bandId).maybeSingle(),
     [bandId, supabase]
   );
 

--- a/hooks/useBands.ts
+++ b/hooks/useBands.ts
@@ -7,8 +7,13 @@ export interface BandsComposite {
   id: number;
   name: string;
   created_at: string;
+  archived_at: string | null;
   song_count: number;
   member_count: number;
+}
+
+interface UseBandsOptions {
+  includeArchived?: boolean;
 }
 
 interface UseBandsResult {
@@ -17,13 +22,13 @@ interface UseBandsResult {
   error?: Error;
 }
 
-export default function useBands(): UseBandsResult {
+export default function useBands({ includeArchived = false }: UseBandsOptions = {}): UseBandsResult {
   const supabase = createClient();
 
   const { data, isLoading, error } = useSWR(
-    'my-bands',
+    `my-bands-${includeArchived ? 'archived' : 'active'}`,
     async () => {
-      const { data, error } = await supabase.rpc('get_my_bands');
+      const { data, error } = await supabase.rpc('get_my_bands', { archived_only: includeArchived });
       if (error) throw error;
       return data as BandsComposite[];
     },

--- a/supabase/migrations/20240110000000_band_archive.sql
+++ b/supabase/migrations/20240110000000_band_archive.sql
@@ -1,0 +1,44 @@
+-- Add archived_at column to bands table
+alter table public.bands add column if not exists archived_at timestamptz;
+
+-- Allow band members to update band (needed for archive/unarchive)
+create policy "band members can update their bands"
+  on public.bands for update
+  to authenticated
+  using (public.is_band_member(id))
+  with check (public.is_band_member(id));
+
+-- Update get_my_bands() to expose archived_at and support filtering by archive status.
+-- archived_only = false (default) returns only active bands.
+-- archived_only = true returns only archived bands.
+create or replace function public.get_my_bands(archived_only boolean default false)
+returns table(
+  id           bigint,
+  name         text,
+  created_at   timestamptz,
+  archived_at  timestamptz,
+  song_count   bigint,
+  member_count bigint
+)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select
+    b.id,
+    b.name,
+    b.created_at,
+    b.archived_at,
+    (select count(*) from public.songs      s   where s.band_id  = b.id) as song_count,
+    (select count(*) from public.band_members bm2 where bm2.band_id = b.id) as member_count
+  from public.bands b
+  inner join public.band_members bm
+    on bm.band_id = b.id and bm.user_id = auth.uid()
+  where
+    case when archived_only
+      then b.archived_at is not null
+      else b.archived_at is null
+    end
+  order by b.name;
+$$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -154,16 +154,19 @@ export type Database = {
       }
       bands: {
         Row: {
+          archived_at: string | null
           created_at: string
           id: number
           name: string
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           id?: number
           name: string
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           id?: number
           name?: string


### PR DESCRIPTION
## Summary

- Adds an **Archive band / Unarchive band** button to each band's header, with an "Archived" chip shown when the band is archived
- Archived bands are **hidden from the dashboard** by default; a **"View archived bands"** toggle reveals them in a separate section below active bands
- Archiving is non-destructive — all songs, setlists, and members are preserved

## Implementation details

- **Migration** (`20240109000000_band_archive.sql`): adds `archived_at timestamptz` to `bands`, adds an RLS update policy so band members can archive their own bands, and updates `get_my_bands()` to expose `archived_at` and accept an `archived_only boolean` parameter (defaults to `false`, keeping existing callers unaffected)
- **API route** (`POST /api/bands/:id/archive`): toggles `archived_at` between `now()` and `null`
- **`useBands` hook**: accepts `{ includeArchived }` option; passes `archived_only` to the RPC; uses scoped SWR cache keys (`my-bands-active` / `my-bands-archived`)
- **`Bands` component**: split into a `BandList` sub-component; adds the archive toggle button and archived section
- **Band layout**: adds the archive/unarchive button and "Archived" chip to the band header

## Test plan

- [ ] Archive a band → it disappears from the dashboard
- [ ] Click "View archived bands" → archived band appears in the archived section
- [ ] Navigate to an archived band's page → "Archived" chip and "Unarchive band" button are visible
- [ ] Unarchive the band → it returns to the active list and disappears from archived
- [ ] Verify `get_my_bands()` with no arguments still returns only active bands (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)