### PR TITLE
Add band events calendar with gigs and practices

### DIFF
--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -1,9 +1,13 @@
+'use client';
+
+import BandEventsCalendar from '@/components/BandEventsCalendar';
 import Card, { CardProps } from '@/components/design/Card';
 import ResponsiveGrid from '@/components/design/ResponsiveGrid';
 import ChecklistIcon from '@mui/icons-material/Checklist';
 import GroupIcon from '@mui/icons-material/Group';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
 import QueueMusicIcon from '@mui/icons-material/QueueMusic';
+import Divider from '@mui/material/Divider';
 import { useMemo } from 'react';
 import { BandRouteProps } from './types';
 
@@ -49,5 +53,11 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
     }));
   }, [actions]);
 
-  return <ResponsiveGrid items={responsiveGridItems} />;
+  return (
+    <>
+      <ResponsiveGrid items={responsiveGridItems} />
+      <Divider sx={{ mt: 2 }} />
+      <BandEventsCalendar bandId={bandId} />
+    </>
+  );
 }

--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -55,9 +55,9 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
 
   return (
     <>
-      <ResponsiveGrid items={responsiveGridItems} />
-      <Divider sx={{ mt: 2 }} />
       <BandEventsCalendar bandId={bandId} />
+      <Divider sx={{ my: 3 }} />
+      <ResponsiveGrid items={responsiveGridItems} />
     </>
   );
 }

--- a/components/AddEventForm.tsx
+++ b/components/AddEventForm.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { EventType } from '@/types/composites';
+import { createClient } from '@/utils/supabase/client';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import TextField from '@mui/material/TextField';
+import { useState } from 'react';
+
+interface AddEventFormProps {
+  bandId: number;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export default function AddEventForm({ bandId, onSuccess, onCancel }: AddEventFormProps) {
+  const [type, setType] = useState<EventType>('practice');
+  const [location, setLocation] = useState('');
+  const [date, setDate] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!location.trim() || !date) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { error: insertError } = await supabase.from('band_events').insert({
+      band_id: bandId,
+      type,
+      location: location.trim(),
+      date,
+    });
+
+    if (insertError) {
+      setError(insertError.message);
+      setSubmitting(false);
+    } else {
+      onSuccess();
+    }
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+      <FormControl fullWidth size="small">
+        <InputLabel>Type</InputLabel>
+        <Select
+          value={type}
+          label="Type"
+          onChange={(e) => setType(e.target.value as EventType)}
+        >
+          <MenuItem value="practice">Practice</MenuItem>
+          <MenuItem value="gig">Gig</MenuItem>
+        </Select>
+      </FormControl>
+
+      <TextField
+        label="Location"
+        size="small"
+        value={location}
+        onChange={(e) => setLocation(e.target.value)}
+        required
+        fullWidth
+        placeholder="e.g. Rehearsal Studio, The Roxy"
+      />
+
+      <TextField
+        label="Date"
+        type="date"
+        size="small"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        required
+        fullWidth
+        InputLabelProps={{ shrink: true }}
+      />
+
+      {error && (
+        <Box sx={{ color: 'error.main', typography: 'caption' }}>{error}</Box>
+      )}
+
+      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+        <Button variant="text" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button variant="contained" type="submit" disabled={submitting || !location.trim() || !date}>
+          Add Event
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/components/AddEventForm.tsx
+++ b/components/AddEventForm.tsx
@@ -21,6 +21,7 @@ export default function AddEventForm({ bandId, onSuccess, onCancel }: AddEventFo
   const [type, setType] = useState<EventType>('practice');
   const [location, setLocation] = useState('');
   const [date, setDate] = useState('');
+  const [time, setTime] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -37,6 +38,7 @@ export default function AddEventForm({ bandId, onSuccess, onCancel }: AddEventFo
       type,
       location: location.trim(),
       date,
+      time: time || null,
     });
 
     if (insertError) {
@@ -71,16 +73,27 @@ export default function AddEventForm({ bandId, onSuccess, onCancel }: AddEventFo
         placeholder="e.g. Rehearsal Studio, The Roxy"
       />
 
-      <TextField
-        label="Date"
-        type="date"
-        size="small"
-        value={date}
-        onChange={(e) => setDate(e.target.value)}
-        required
-        fullWidth
-        InputLabelProps={{ shrink: true }}
-      />
+      <Box sx={{ display: 'flex', gap: 1.5 }}>
+        <TextField
+          label="Date"
+          type="date"
+          size="small"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          required
+          fullWidth
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="Time"
+          type="time"
+          size="small"
+          value={time}
+          onChange={(e) => setTime(e.target.value)}
+          fullWidth
+          InputLabelProps={{ shrink: true }}
+        />
+      </Box>
 
       {error && (
         <Box sx={{ color: 'error.main', typography: 'caption' }}>{error}</Box>

--- a/components/BandEventsCalendar.tsx
+++ b/components/BandEventsCalendar.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import AddEventForm from '@/components/AddEventForm';
+import useBandEvents from '@/hooks/useBandEvents';
+import { BandEvent } from '@/types/composites';
+import { createClient } from '@/utils/supabase/client';
+import AddIcon from '@mui/icons-material/Add';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import MicIcon from '@mui/icons-material/Mic';
+import MusicNoteIcon from '@mui/icons-material/MusicNote';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useMemo, useState } from 'react';
+
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+function formatDisplayDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const d = new Date(year, month - 1, day);
+  return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function EventIcon({ type }: { type: BandEvent['type'] }) {
+  return type === 'gig'
+    ? <MicIcon sx={{ fontSize: 14 }} />
+    : <MusicNoteIcon sx={{ fontSize: 14 }} />;
+}
+
+function EventChip({ type }: { type: BandEvent['type'] }) {
+  return (
+    <Chip
+      size="small"
+      icon={<EventIcon type={type} />}
+      label={type === 'gig' ? 'Gig' : 'Practice'}
+      color={type === 'gig' ? 'primary' : 'default'}
+      variant={type === 'gig' ? 'filled' : 'outlined'}
+      sx={{ fontSize: 11, height: 20 }}
+    />
+  );
+}
+
+interface EventRowProps {
+  event: BandEvent;
+  onDelete: () => void;
+}
+
+function EventRow({ event, onDelete }: EventRowProps) {
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    const supabase = createClient();
+    await supabase.from('band_events').delete().eq('id', event.id);
+    onDelete();
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        py: 1,
+        px: 1.5,
+        borderRadius: 1,
+        '&:hover': { bgcolor: 'action.hover' },
+      }}
+    >
+      <Box sx={{ flexShrink: 0 }}>
+        <EventChip type={event.type} />
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography variant="body2" fontWeight={500} noWrap>
+          {event.location}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {formatDisplayDate(event.date)}
+        </Typography>
+      </Box>
+      <Tooltip title="Delete event">
+        <IconButton size="small" onClick={handleDelete} disabled={deleting} sx={{ flexShrink: 0, opacity: 0.5, '&:hover': { opacity: 1 } }}>
+          <DeleteOutlineIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}
+
+interface CalendarGridProps {
+  year: number;
+  month: number;
+  eventDates: Set<string>;
+  selectedDate: string | null;
+  today: string;
+  onSelectDate: (date: string | null) => void;
+}
+
+function CalendarGrid({ year, month, eventDates, selectedDate, today, onSelectDate }: CalendarGridProps) {
+  const cells = useMemo(() => {
+    const firstDay = new Date(year, month, 1).getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const result: (number | null)[] = Array(firstDay).fill(null);
+    for (let d = 1; d <= daysInMonth; d++) result.push(d);
+    while (result.length % 7 !== 0) result.push(null);
+    return result;
+  }, [year, month]);
+
+  return (
+    <Box>
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', mb: 0.5 }}>
+        {DAY_NAMES.map((d) => (
+          <Typography key={d} variant="caption" color="text.secondary" align="center" sx={{ py: 0.5 }}>
+            {d}
+          </Typography>
+        ))}
+      </Box>
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 0.25 }}>
+        {cells.map((day, i) => {
+          if (!day) return <Box key={i} />;
+          const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+          const hasEvent = eventDates.has(dateStr);
+          const isToday = dateStr === today;
+          const isSelected = dateStr === selectedDate;
+
+          return (
+            <Box
+              key={i}
+              onClick={() => onSelectDate(isSelected ? null : dateStr)}
+              sx={{
+                position: 'relative',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                aspectRatio: '1',
+                borderRadius: 1,
+                cursor: hasEvent ? 'pointer' : 'default',
+                bgcolor: isSelected ? 'primary.main' : isToday ? 'action.selected' : 'transparent',
+                '&:hover': hasEvent ? { bgcolor: isSelected ? 'primary.dark' : 'action.hover' } : {},
+                border: isToday && !isSelected ? '1px solid' : 'none',
+                borderColor: 'primary.main',
+              }}
+            >
+              <Typography
+                variant="caption"
+                sx={{
+                  fontWeight: isToday || hasEvent ? 600 : 400,
+                  color: isSelected ? 'primary.contrastText' : 'text.primary',
+                  lineHeight: 1,
+                }}
+              >
+                {day}
+              </Typography>
+              {hasEvent && (
+                <Box
+                  sx={{
+                    width: 4,
+                    height: 4,
+                    borderRadius: '50%',
+                    bgcolor: isSelected ? 'primary.contrastText' : 'primary.main',
+                    mt: 0.25,
+                  }}
+                />
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}
+
+interface BandEventsCalendarProps {
+  bandId: number;
+}
+
+export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) {
+  const { data: events, isLoading, mutate } = useBandEvents({ bandId });
+  const [addOpen, setAddOpen] = useState(false);
+  const [tab, setTab] = useState<'upcoming' | 'past'>('upcoming');
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  const todayStr = useMemo(() => {
+    const t = new Date();
+    return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}-${String(t.getDate()).padStart(2, '0')}`;
+  }, []);
+
+  const [calYear, setCalYear] = useState(() => new Date().getFullYear());
+  const [calMonth, setCalMonth] = useState(() => new Date().getMonth());
+
+  const eventDates = useMemo(() => {
+    const s = new Set<string>();
+    events?.forEach((e) => s.add(e.date));
+    return s;
+  }, [events]);
+
+  const upcoming = useMemo(
+    () => (events ?? []).filter((e) => e.date >= todayStr),
+    [events, todayStr]
+  );
+
+  const past = useMemo(
+    () => (events ?? []).filter((e) => e.date < todayStr).reverse(),
+    [events, todayStr]
+  );
+
+  const filteredByDate = useMemo(() => {
+    if (!selectedDate) return null;
+    return (events ?? []).filter((e) => e.date === selectedDate);
+  }, [events, selectedDate]);
+
+  const displayList = filteredByDate ?? (tab === 'upcoming' ? upcoming : past);
+
+  const prevMonth = () => {
+    if (calMonth === 0) { setCalMonth(11); setCalYear((y) => y - 1); }
+    else setCalMonth((m) => m - 1);
+  };
+
+  const nextMonth = () => {
+    if (calMonth === 11) { setCalMonth(0); setCalYear((y) => y + 1); }
+    else setCalMonth((m) => m + 1);
+  };
+
+  const handleDelete = () => {
+    mutate();
+  };
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 1 }}>
+        <Typography variant="h6" fontWeight={600}>
+          Events
+        </Typography>
+        <Box sx={{ ml: 'auto' }}>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={() => setAddOpen(true)}
+          >
+            Add Event
+          </Button>
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 3,
+          flexDirection: { xs: 'column', md: 'row' },
+          alignItems: { xs: 'stretch', md: 'flex-start' },
+        }}
+      >
+        {/* Calendar grid */}
+        <Box sx={{ flexShrink: 0, width: { xs: '100%', md: 260 } }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+            <IconButton size="small" onClick={prevMonth}>
+              <ChevronLeftIcon fontSize="small" />
+            </IconButton>
+            <Typography variant="body2" fontWeight={600} sx={{ flex: 1, textAlign: 'center' }}>
+              {MONTH_NAMES[calMonth]} {calYear}
+            </Typography>
+            <IconButton size="small" onClick={nextMonth}>
+              <ChevronRightIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <CalendarGrid
+            year={calYear}
+            month={calMonth}
+            eventDates={eventDates}
+            selectedDate={selectedDate}
+            today={todayStr}
+            onSelectDate={(d) => {
+              setSelectedDate(d);
+              if (d) {
+                const isPast = d < todayStr;
+                setTab(isPast ? 'past' : 'upcoming');
+              }
+            }}
+          />
+          {selectedDate && (
+            <Button size="small" sx={{ mt: 1 }} onClick={() => setSelectedDate(null)}>
+              Clear filter
+            </Button>
+          )}
+        </Box>
+
+        <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', md: 'block' } }} />
+        <Divider sx={{ display: { xs: 'block', md: 'none' } }} />
+
+        {/* Event list */}
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          {!selectedDate && (
+            <Tabs
+              value={tab}
+              onChange={(_, v) => setTab(v)}
+              sx={{ mb: 1, minHeight: 36, '& .MuiTab-root': { minHeight: 36, py: 0 } }}
+            >
+              <Tab
+                label={`Upcoming${upcoming.length ? ` (${upcoming.length})` : ''}`}
+                value="upcoming"
+              />
+              <Tab
+                label={`Past${past.length ? ` (${past.length})` : ''}`}
+                value="past"
+              />
+            </Tabs>
+          )}
+
+          {selectedDate && (
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1, fontWeight: 500 }}>
+              {formatDisplayDate(selectedDate)}
+            </Typography>
+          )}
+
+          {isLoading ? (
+            <Typography variant="body2" color="text.secondary">Loading…</Typography>
+          ) : displayList.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+              {selectedDate ? 'No events on this day.' : tab === 'upcoming' ? 'No upcoming events.' : 'No past events.'}
+            </Typography>
+          ) : (
+            <Box>
+              {displayList.map((event, i) => (
+                <EventRow key={i} event={event} onDelete={handleDelete} />
+              ))}
+            </Box>
+          )}
+        </Box>
+      </Box>
+
+      <Dialog open={addOpen} onClose={() => setAddOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Add Event</DialogTitle>
+        <DialogContent>
+          <AddEventForm
+            bandId={bandId}
+            onSuccess={() => {
+              setAddOpen(false);
+              mutate();
+            }}
+            onCancel={() => setAddOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+    </Box>
+  );
+}

--- a/components/BandEventsCalendar.tsx
+++ b/components/BandEventsCalendar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import AddEventForm from '@/components/AddEventForm';
+import EventForm from '@/components/EventForm';
 import useBandEvents from '@/hooks/useBandEvents';
 import { BandEvent } from '@/types/composites';
 import { createClient } from '@/utils/supabase/client';
@@ -9,6 +9,7 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import MicIcon from '@mui/icons-material/Mic';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import ViewListIcon from '@mui/icons-material/ViewList';
@@ -71,64 +72,83 @@ function EventChip({ type }: { type: BandEvent['type'] }) {
 
 interface EventRowProps {
   event: BandEvent;
-  onDelete: () => void;
+  bandId: number;
+  onMutate: () => void;
 }
 
-function EventRow({ event, onDelete }: EventRowProps) {
+function EventRow({ event, bandId, onMutate }: EventRowProps) {
   const [deleting, setDeleting] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
 
   const handleDelete = async () => {
     setDeleting(true);
     const supabase = createClient();
     await supabase.from('band_events').delete().eq('id', event.id);
-    onDelete();
+    onMutate();
   };
 
+  const iconSx = { flexShrink: 0, opacity: 0.5, '&:hover': { opacity: 1 } };
+
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 1.5,
-        py: 1,
-        px: 1.5,
-        borderRadius: 1,
-        '&:hover': { bgcolor: 'action.hover' },
-      }}
-    >
-      <Box sx={{ flexShrink: 0 }}>
-        <EventChip type={event.type} />
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          py: 1,
+          px: 1.5,
+          borderRadius: 1,
+          '&:hover': { bgcolor: 'action.hover' },
+        }}
+      >
+        <Box sx={{ flexShrink: 0 }}>
+          <EventChip type={event.type} />
+        </Box>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="body2" fontWeight={500} noWrap>
+            {event.location}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {formatDateTime(event.date, event.time)}
+          </Typography>
+        </Box>
+        <Tooltip title="Edit event">
+          <IconButton size="small" onClick={() => setEditOpen(true)} sx={iconSx}>
+            <EditOutlinedIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Delete event">
+          <IconButton size="small" onClick={handleDelete} disabled={deleting} sx={iconSx}>
+            <DeleteOutlineIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
       </Box>
-      <Box sx={{ flex: 1, minWidth: 0 }}>
-        <Typography variant="body2" fontWeight={500} noWrap>
-          {event.location}
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          {formatDateTime(event.date, event.time)}
-        </Typography>
-      </Box>
-      <Tooltip title="Delete event">
-        <IconButton
-          size="small"
-          onClick={handleDelete}
-          disabled={deleting}
-          sx={{ flexShrink: 0, opacity: 0.5, '&:hover': { opacity: 1 } }}
-        >
-          <DeleteOutlineIcon fontSize="small" />
-        </IconButton>
-      </Tooltip>
-    </Box>
+
+      <Dialog open={editOpen} onClose={() => setEditOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Edit Event</DialogTitle>
+        <DialogContent>
+          <EventForm
+            bandId={bandId}
+            event={event}
+            onSuccess={() => { setEditOpen(false); onMutate(); }}
+            onCancel={() => setEditOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
 interface EventListProps {
   events: BandEvent[];
+  bandId: number;
   isLoading: boolean;
   emptyMessage: string;
-  onDelete: () => void;
+  onMutate: () => void;
 }
 
-function EventList({ events, isLoading, emptyMessage, onDelete }: EventListProps) {
+function EventList({ events, bandId, isLoading, emptyMessage, onMutate }: EventListProps) {
   if (isLoading) {
     return <Typography variant="body2" color="text.secondary">Loading…</Typography>;
   }
@@ -142,7 +162,7 @@ function EventList({ events, isLoading, emptyMessage, onDelete }: EventListProps
   return (
     <Box>
       {events.map((event, i) => (
-        <EventRow key={i} event={event} onDelete={onDelete} />
+        <EventRow key={i} event={event} bandId={bandId} onMutate={onMutate} />
       ))}
     </Box>
   );
@@ -267,7 +287,7 @@ export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) 
     return (events ?? []).filter((e) => e.date === selectedDate);
   }, [events, selectedDate]);
 
-  const handleDelete = () => mutate();
+  const handleMutate = () => mutate();
 
   const prevMonth = () => {
     if (calMonth === 0) { setCalMonth(11); setCalYear((y) => y - 1); }
@@ -341,7 +361,8 @@ export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) 
             events={tab === 'upcoming' ? upcoming : past}
             isLoading={isLoading}
             emptyMessage={tab === 'upcoming' ? 'No upcoming events.' : 'No past events.'}
-            onDelete={handleDelete}
+            bandId={bandId}
+            onMutate={handleMutate}
           />
         </Box>
       ) : (
@@ -397,9 +418,10 @@ export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) 
                 </Typography>
                 <EventList
                   events={filteredByDate ?? []}
+                  bandId={bandId}
                   isLoading={isLoading}
                   emptyMessage="No events on this day."
-                  onDelete={handleDelete}
+                  onMutate={handleMutate}
                 />
               </>
             ) : (
@@ -414,9 +436,10 @@ export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) 
                 </Tabs>
                 <EventList
                   events={tab === 'upcoming' ? upcoming : past}
+                  bandId={bandId}
                   isLoading={isLoading}
                   emptyMessage={tab === 'upcoming' ? 'No upcoming events.' : 'No past events.'}
-                  onDelete={handleDelete}
+                  onMutate={handleMutate}
                 />
               </>
             )}
@@ -427,12 +450,9 @@ export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) 
       <Dialog open={addOpen} onClose={() => setAddOpen(false)} maxWidth="xs" fullWidth>
         <DialogTitle>Add Event</DialogTitle>
         <DialogContent>
-          <AddEventForm
+          <EventForm
             bandId={bandId}
-            onSuccess={() => {
-              setAddOpen(false);
-              mutate();
-            }}
+            onSuccess={() => { setAddOpen(false); mutate(); }}
             onCancel={() => setAddOpen(false)}
           />
         </DialogContent>

--- a/components/BandEventsCalendar.tsx
+++ b/components/BandEventsCalendar.tsx
@@ -5,11 +5,13 @@ import useBandEvents from '@/hooks/useBandEvents';
 import { BandEvent } from '@/types/composites';
 import { createClient } from '@/utils/supabase/client';
 import AddIcon from '@mui/icons-material/Add';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import MicIcon from '@mui/icons-material/Mic';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
+import ViewListIcon from '@mui/icons-material/ViewList';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -20,6 +22,8 @@ import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useMemo, useState } from 'react';
@@ -31,10 +35,19 @@ const MONTH_NAMES = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
 
-function formatDisplayDate(dateStr: string): string {
+function todayDateStr(): string {
+  const t = new Date();
+  return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}-${String(t.getDate()).padStart(2, '0')}`;
+}
+
+function formatDateTime(dateStr: string, timeStr: string | null): string {
   const [year, month, day] = dateStr.split('-').map(Number);
   const d = new Date(year, month - 1, day);
-  return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+  const datePart = d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+  if (!timeStr) return datePart;
+  const [hours, minutes] = timeStr.split(':').map(Number);
+  const t = new Date(year, month - 1, day, hours, minutes);
+  return datePart + ' · ' + t.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
 }
 
 function EventIcon({ type }: { type: BandEvent['type'] }) {
@@ -91,14 +104,46 @@ function EventRow({ event, onDelete }: EventRowProps) {
           {event.location}
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          {formatDisplayDate(event.date)}
+          {formatDateTime(event.date, event.time)}
         </Typography>
       </Box>
       <Tooltip title="Delete event">
-        <IconButton size="small" onClick={handleDelete} disabled={deleting} sx={{ flexShrink: 0, opacity: 0.5, '&:hover': { opacity: 1 } }}>
+        <IconButton
+          size="small"
+          onClick={handleDelete}
+          disabled={deleting}
+          sx={{ flexShrink: 0, opacity: 0.5, '&:hover': { opacity: 1 } }}
+        >
           <DeleteOutlineIcon fontSize="small" />
         </IconButton>
       </Tooltip>
+    </Box>
+  );
+}
+
+interface EventListProps {
+  events: BandEvent[];
+  isLoading: boolean;
+  emptyMessage: string;
+  onDelete: () => void;
+}
+
+function EventList({ events, isLoading, emptyMessage, onDelete }: EventListProps) {
+  if (isLoading) {
+    return <Typography variant="body2" color="text.secondary">Loading…</Typography>;
+  }
+  if (events.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>
+        {emptyMessage}
+      </Typography>
+    );
+  }
+  return (
+    <Box>
+      {events.map((event, i) => (
+        <EventRow key={i} event={event} onDelete={onDelete} />
+      ))}
     </Box>
   );
 }
@@ -144,7 +189,6 @@ function CalendarGrid({ year, month, eventDates, selectedDate, today, onSelectDa
               key={i}
               onClick={() => onSelectDate(isSelected ? null : dateStr)}
               sx={{
-                position: 'relative',
                 display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',
@@ -194,16 +238,13 @@ interface BandEventsCalendarProps {
 export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) {
   const { data: events, isLoading, mutate } = useBandEvents({ bandId });
   const [addOpen, setAddOpen] = useState(false);
+  const [view, setView] = useState<'list' | 'calendar'>('list');
   const [tab, setTab] = useState<'upcoming' | 'past'>('upcoming');
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
-
-  const todayStr = useMemo(() => {
-    const t = new Date();
-    return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}-${String(t.getDate()).padStart(2, '0')}`;
-  }, []);
-
   const [calYear, setCalYear] = useState(() => new Date().getFullYear());
   const [calMonth, setCalMonth] = useState(() => new Date().getMonth());
+
+  const today = useMemo(todayDateStr, []);
 
   const eventDates = useMemo(() => {
     const s = new Set<string>();
@@ -212,13 +253,13 @@ export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) 
   }, [events]);
 
   const upcoming = useMemo(
-    () => (events ?? []).filter((e) => e.date >= todayStr),
-    [events, todayStr]
+    () => (events ?? []).filter((e) => e.date >= today),
+    [events, today]
   );
 
   const past = useMemo(
-    () => (events ?? []).filter((e) => e.date < todayStr).reverse(),
-    [events, todayStr]
+    () => (events ?? []).filter((e) => e.date < today).reverse(),
+    [events, today]
   );
 
   const filteredByDate = useMemo(() => {
@@ -226,7 +267,7 @@ export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) 
     return (events ?? []).filter((e) => e.date === selectedDate);
   }, [events, selectedDate]);
 
-  const displayList = filteredByDate ?? (tab === 'upcoming' ? upcoming : past);
+  const handleDelete = () => mutate();
 
   const prevMonth = () => {
     if (calMonth === 0) { setCalMonth(11); setCalYear((y) => y - 1); }
@@ -238,17 +279,36 @@ export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) 
     else setCalMonth((m) => m + 1);
   };
 
-  const handleDelete = () => {
-    mutate();
-  };
-
   return (
-    <Box sx={{ mt: 4 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 1 }}>
+    <Box>
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 1, flexWrap: 'wrap' }}>
         <Typography variant="h6" fontWeight={600}>
           Events
         </Typography>
-        <Box sx={{ ml: 'auto' }}>
+        <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 1 }}>
+          <ToggleButtonGroup
+            value={view}
+            exclusive
+            size="small"
+            onChange={(_, v) => {
+              if (v) {
+                setView(v);
+                setSelectedDate(null);
+              }
+            }}
+          >
+            <ToggleButton value="list" aria-label="list view">
+              <Tooltip title="List view">
+                <ViewListIcon fontSize="small" />
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton value="calendar" aria-label="calendar view">
+              <Tooltip title="Calendar view">
+                <CalendarMonthIcon fontSize="small" />
+              </Tooltip>
+            </ToggleButton>
+          </ToggleButtonGroup>
           <Button
             variant="outlined"
             size="small"
@@ -260,91 +320,109 @@ export default function BandEventsCalendar({ bandId }: BandEventsCalendarProps) 
         </Box>
       </Box>
 
-      <Box
-        sx={{
-          display: 'flex',
-          gap: 3,
-          flexDirection: { xs: 'column', md: 'row' },
-          alignItems: { xs: 'stretch', md: 'flex-start' },
-        }}
-      >
-        {/* Calendar grid */}
-        <Box sx={{ flexShrink: 0, width: { xs: '100%', md: 260 } }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-            <IconButton size="small" onClick={prevMonth}>
-              <ChevronLeftIcon fontSize="small" />
-            </IconButton>
-            <Typography variant="body2" fontWeight={600} sx={{ flex: 1, textAlign: 'center' }}>
-              {MONTH_NAMES[calMonth]} {calYear}
-            </Typography>
-            <IconButton size="small" onClick={nextMonth}>
-              <ChevronRightIcon fontSize="small" />
-            </IconButton>
-          </Box>
-          <CalendarGrid
-            year={calYear}
-            month={calMonth}
-            eventDates={eventDates}
-            selectedDate={selectedDate}
-            today={todayStr}
-            onSelectDate={(d) => {
-              setSelectedDate(d);
-              if (d) {
-                const isPast = d < todayStr;
-                setTab(isPast ? 'past' : 'upcoming');
-              }
-            }}
+      {view === 'list' ? (
+        /* ── List view ── */
+        <Box>
+          <Tabs
+            value={tab}
+            onChange={(_, v) => setTab(v)}
+            sx={{ mb: 1.5, minHeight: 36, '& .MuiTab-root': { minHeight: 36, py: 0 } }}
+          >
+            <Tab
+              label={`Upcoming${upcoming.length ? ` (${upcoming.length})` : ''}`}
+              value="upcoming"
+            />
+            <Tab
+              label={`Past${past.length ? ` (${past.length})` : ''}`}
+              value="past"
+            />
+          </Tabs>
+          <EventList
+            events={tab === 'upcoming' ? upcoming : past}
+            isLoading={isLoading}
+            emptyMessage={tab === 'upcoming' ? 'No upcoming events.' : 'No past events.'}
+            onDelete={handleDelete}
           />
-          {selectedDate && (
-            <Button size="small" sx={{ mt: 1 }} onClick={() => setSelectedDate(null)}>
-              Clear filter
-            </Button>
-          )}
         </Box>
-
-        <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', md: 'block' } }} />
-        <Divider sx={{ display: { xs: 'block', md: 'none' } }} />
-
-        {/* Event list */}
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          {!selectedDate && (
-            <Tabs
-              value={tab}
-              onChange={(_, v) => setTab(v)}
-              sx={{ mb: 1, minHeight: 36, '& .MuiTab-root': { minHeight: 36, py: 0 } }}
-            >
-              <Tab
-                label={`Upcoming${upcoming.length ? ` (${upcoming.length})` : ''}`}
-                value="upcoming"
-              />
-              <Tab
-                label={`Past${past.length ? ` (${past.length})` : ''}`}
-                value="past"
-              />
-            </Tabs>
-          )}
-
-          {selectedDate && (
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1, fontWeight: 500 }}>
-              {formatDisplayDate(selectedDate)}
-            </Typography>
-          )}
-
-          {isLoading ? (
-            <Typography variant="body2" color="text.secondary">Loading…</Typography>
-          ) : displayList.length === 0 ? (
-            <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-              {selectedDate ? 'No events on this day.' : tab === 'upcoming' ? 'No upcoming events.' : 'No past events.'}
-            </Typography>
-          ) : (
-            <Box>
-              {displayList.map((event, i) => (
-                <EventRow key={i} event={event} onDelete={handleDelete} />
-              ))}
+      ) : (
+        /* ── Calendar view ── */
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 3,
+            flexDirection: { xs: 'column', md: 'row' },
+            alignItems: { xs: 'stretch', md: 'flex-start' },
+          }}
+        >
+          {/* Month grid */}
+          <Box sx={{ flexShrink: 0, width: { xs: '100%', md: 260 } }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+              <IconButton size="small" onClick={prevMonth}>
+                <ChevronLeftIcon fontSize="small" />
+              </IconButton>
+              <Typography variant="body2" fontWeight={600} sx={{ flex: 1, textAlign: 'center' }}>
+                {MONTH_NAMES[calMonth]} {calYear}
+              </Typography>
+              <IconButton size="small" onClick={nextMonth}>
+                <ChevronRightIcon fontSize="small" />
+              </IconButton>
             </Box>
-          )}
+            <CalendarGrid
+              year={calYear}
+              month={calMonth}
+              eventDates={eventDates}
+              selectedDate={selectedDate}
+              today={today}
+              onSelectDate={(d) => {
+                setSelectedDate(d);
+                if (d) setTab(d < today ? 'past' : 'upcoming');
+              }}
+            />
+            {selectedDate && (
+              <Button size="small" sx={{ mt: 1 }} onClick={() => setSelectedDate(null)}>
+                Clear filter
+              </Button>
+            )}
+          </Box>
+
+          <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', md: 'block' } }} />
+          <Divider sx={{ display: { xs: 'block', md: 'none' } }} />
+
+          {/* Event list */}
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {selectedDate ? (
+              <>
+                <Typography variant="body2" fontWeight={500} color="text.secondary" sx={{ mb: 1 }}>
+                  {formatDateTime(selectedDate, null)}
+                </Typography>
+                <EventList
+                  events={filteredByDate ?? []}
+                  isLoading={isLoading}
+                  emptyMessage="No events on this day."
+                  onDelete={handleDelete}
+                />
+              </>
+            ) : (
+              <>
+                <Tabs
+                  value={tab}
+                  onChange={(_, v) => setTab(v)}
+                  sx={{ mb: 1, minHeight: 36, '& .MuiTab-root': { minHeight: 36, py: 0 } }}
+                >
+                  <Tab label={`Upcoming${upcoming.length ? ` (${upcoming.length})` : ''}`} value="upcoming" />
+                  <Tab label={`Past${past.length ? ` (${past.length})` : ''}`} value="past" />
+                </Tabs>
+                <EventList
+                  events={tab === 'upcoming' ? upcoming : past}
+                  isLoading={isLoading}
+                  emptyMessage={tab === 'upcoming' ? 'No upcoming events.' : 'No past events.'}
+                  onDelete={handleDelete}
+                />
+              </>
+            )}
+          </Box>
         </Box>
-      </Box>
+      )}
 
       <Dialog open={addOpen} onClose={() => setAddOpen(false)} maxWidth="xs" fullWidth>
         <DialogTitle>Add Event</DialogTitle>

--- a/components/EventForm.tsx
+++ b/components/EventForm.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { BandEvent, EventType } from '@/types/composites';
+import { createClient } from '@/utils/supabase/client';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import TextField from '@mui/material/TextField';
+import { useState } from 'react';
+
+interface EventFormProps {
+  bandId: number;
+  event?: BandEvent;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export default function EventForm({ bandId, event, onSuccess, onCancel }: EventFormProps) {
+  const isEdit = !!event;
+  const [type, setType] = useState<EventType>(event?.type ?? 'practice');
+  const [location, setLocation] = useState(event?.location ?? '');
+  const [date, setDate] = useState(event?.date ?? '');
+  // PostgreSQL returns time as "HH:MM:SS"; <input type="time"> needs "HH:MM"
+  const [time, setTime] = useState(event?.time ? event.time.slice(0, 5) : '');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!location.trim() || !date) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    const supabase = createClient();
+    const payload = {
+      type,
+      location: location.trim(),
+      date,
+      time: time || null,
+    };
+
+    const { error: dbError } = isEdit
+      ? await supabase.from('band_events').update(payload).eq('id', event.id)
+      : await supabase.from('band_events').insert({ ...payload, band_id: bandId });
+
+    if (dbError) {
+      setError(dbError.message);
+      setSubmitting(false);
+    } else {
+      onSuccess();
+    }
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+      <FormControl fullWidth size="small">
+        <InputLabel>Type</InputLabel>
+        <Select
+          value={type}
+          label="Type"
+          onChange={(e) => setType(e.target.value as EventType)}
+        >
+          <MenuItem value="practice">Practice</MenuItem>
+          <MenuItem value="gig">Gig</MenuItem>
+        </Select>
+      </FormControl>
+
+      <TextField
+        label="Location"
+        size="small"
+        value={location}
+        onChange={(e) => setLocation(e.target.value)}
+        required
+        fullWidth
+        placeholder="e.g. Rehearsal Studio, The Roxy"
+      />
+
+      <Box sx={{ display: 'flex', gap: 1.5 }}>
+        <TextField
+          label="Date"
+          type="date"
+          size="small"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          required
+          fullWidth
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="Time"
+          type="time"
+          size="small"
+          value={time}
+          onChange={(e) => setTime(e.target.value)}
+          fullWidth
+          InputLabelProps={{ shrink: true }}
+        />
+      </Box>
+
+      {error && (
+        <Box sx={{ color: 'error.main', typography: 'caption' }}>{error}</Box>
+      )}
+
+      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+        <Button variant="text" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button variant="contained" type="submit" disabled={submitting || !location.trim() || !date}>
+          {isEdit ? 'Save Changes' : 'Add Event'}
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/hooks/useBandEvents.ts
+++ b/hooks/useBandEvents.ts
@@ -28,7 +28,8 @@ export default function useBandEvents({ bandId }: UseBandEventsProps): UseBandEv
       .from('band_events')
       .select('*')
       .eq('band_id', bandId)
-      .order('date', { ascending: true });
+      .order('date', { ascending: true })
+      .order('time', { ascending: true, nullsFirst: false });
 
     if (fetchError) {
       setError(fetchError.message);

--- a/hooks/useBandEvents.ts
+++ b/hooks/useBandEvents.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { BandEvent } from '@/types/composites';
+import { createClient } from '@/utils/supabase/client';
+import { useState, useEffect, useCallback } from 'react';
+
+interface UseBandEventsProps {
+  bandId: number;
+}
+
+interface UseBandEventsResult {
+  data: BandEvent[] | null;
+  isLoading: boolean;
+  error: string | null;
+  mutate: () => void;
+}
+
+export default function useBandEvents({ bandId }: UseBandEventsProps): UseBandEventsResult {
+  const [data, setData] = useState<BandEvent[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEvents = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    const supabase = createClient();
+    const { data: events, error: fetchError } = await supabase
+      .from('band_events')
+      .select('*')
+      .eq('band_id', bandId)
+      .order('date', { ascending: true });
+
+    if (fetchError) {
+      setError(fetchError.message);
+    } else {
+      setData(events as BandEvent[]);
+    }
+    setIsLoading(false);
+  }, [bandId]);
+
+  useEffect(() => {
+    fetchEvents();
+  }, [fetchEvents]);
+
+  return { data, isLoading, error, mutate: fetchEvents };
+}

--- a/supabase/migrations/20240111000000_band_events.sql
+++ b/supabase/migrations/20240111000000_band_events.sql
@@ -1,0 +1,26 @@
+create table if not exists public.band_events (
+  id bigint generated always as identity primary key,
+  band_id bigint not null references public.bands(id) on delete cascade,
+  type text not null check (type in ('practice', 'gig')),
+  location text not null,
+  date date not null,
+  created_at timestamp with time zone default now() not null
+);
+
+alter table public.band_events enable row level security;
+
+create policy "Band members can view events"
+  on public.band_events for select
+  using (is_band_member(band_id));
+
+create policy "Band members can insert events"
+  on public.band_events for insert
+  with check (is_band_member(band_id));
+
+create policy "Band members can update events"
+  on public.band_events for update
+  using (is_band_member(band_id));
+
+create policy "Band members can delete events"
+  on public.band_events for delete
+  using (is_band_member(band_id));

--- a/supabase/migrations/20240112000000_band_events_add_time.sql
+++ b/supabase/migrations/20240112000000_band_events_add_time.sql
@@ -1,0 +1,1 @@
+alter table public.band_events add column if not exists time time;

--- a/types/composites.ts
+++ b/types/composites.ts
@@ -12,5 +12,6 @@ export interface BandEvent {
   type: EventType;
   location: string;
   date: string;
+  time: string | null;
   created_at: string;
 }

--- a/types/composites.ts
+++ b/types/composites.ts
@@ -3,3 +3,14 @@ import { Tables } from './supabase';
 export interface SetlistComposite extends Tables<'setlists'> {
   setlist_songs: Tables<'setlist_songs'>[];
 }
+
+export type EventType = 'practice' | 'gig';
+
+export interface BandEvent {
+  id: number;
+  band_id: number;
+  type: EventType;
+  location: string;
+  date: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
This PR adds a comprehensive events management system to the band dashboard, allowing band members to create, view, and manage band events (gigs and practices) with an integrated calendar interface.

## Key Changes
- **New `BandEventsCalendar` component**: Interactive calendar view displaying band events with month navigation, event filtering by date, and upcoming/past event tabs
- **New `AddEventForm` component**: Form for creating new band events with type (gig/practice), location, and date fields
- **New `useBandEvents` hook**: Custom React hook for fetching and managing band events data from Supabase
- **Database migration**: Created `band_events` table with RLS policies to ensure only band members can view/manage events
- **Type definitions**: Added `EventType` and `BandEvent` types to support the new feature
- **Band dashboard integration**: Integrated the events calendar into the band dashboard page

## Implementation Details
- Calendar displays event indicators on dates with events and highlights the current date
- Users can click on dates to filter events by that specific date
- Events are categorized as "Upcoming" or "Past" with visual distinction (gigs use primary color with microphone icon, practices use default color with music note icon)
- Delete functionality for events with confirmation via loading state
- Responsive design that stacks calendar and event list vertically on mobile
- RLS policies ensure data security with band membership validation
- Form includes error handling and submission state management

https://claude.ai/code/session_01VEjuuy5Unn2ynnAiFwjPi5