### PR TITLE
Add print chord charts feature for setlists

### DIFF
--- a/app/band/[bandId]/setlists/page.tsx
+++ b/app/band/[bandId]/setlists/page.tsx
@@ -110,6 +110,12 @@ export default function BandSetlistsPage({ params }: Readonly<BandRouteProps>) {
           >
             Duplicate
           </Button>
+          <Button
+            variant="outlined"
+            onClick={() => window.open(`/print/setlist/${setlistId}/chord-charts`, '_blank')}
+          >
+            Print Chord Charts
+          </Button>
         </Box>
       );
     },

--- a/app/print/setlist/[setlistId]/chord-charts/page.tsx
+++ b/app/print/setlist/[setlistId]/chord-charts/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import Loading from '@/components/design/Loading';
+import ChordChartViewer from '@/components/ChordChartViewer';
+import useSetlistWithSongs from '@/hooks/useSetlistWithSongs';
+import { Tables } from '@/types/supabase';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+import PrintIcon from '@mui/icons-material/Print';
+import { useMemo } from 'react';
+
+interface PrintChordChartsPageProps {
+  params: { setlistId: number };
+}
+
+interface OrderedSong {
+  set: number;
+  setWeight: number;
+  song: Tables<'songs'>;
+}
+
+export default function PrintChordChartsPage({ params }: Readonly<PrintChordChartsPageProps>) {
+  const { setlistId } = params;
+  const { data: setlist, isLoading } = useSetlistWithSongs({ setlistId });
+
+  const orderedSongs = useMemo<OrderedSong[]>(() => {
+    if (!setlist) return [];
+    return [...setlist.setlist_songs]
+      .sort((a, b) => {
+        if (a.set !== b.set) return (a.set ?? 0) - (b.set ?? 0);
+        return (a.set_weight ?? 0) - (b.set_weight ?? 0);
+      })
+      .map((ss) => ({
+        set: ss.set ?? 0,
+        setWeight: ss.set_weight ?? 0,
+        song: ss.songs,
+      }));
+  }, [setlist]);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (!setlist) {
+    return <Typography variant="h5">Setlist not found.</Typography>;
+  }
+
+  const songsWithCharts = orderedSongs.filter((s) => s.song.chord_chart?.trim());
+
+  return (
+    <>
+      <style>{`
+        header, footer { display: none !important; }
+        main { padding-top: 0 !important; }
+        @media print {
+          .no-print { display: none !important; }
+          header, footer { display: none !important; }
+        }
+      `}</style>
+
+      <Box className="no-print" sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Typography variant="h5" fontWeight={700}>
+          {setlist.name} — Chord Charts
+        </Typography>
+        <Button variant="contained" startIcon={<PrintIcon />} onClick={() => window.print()}>
+          Print
+        </Button>
+      </Box>
+
+      {songsWithCharts.length === 0 ? (
+        <Typography color="text.secondary">No songs with chord charts in this setlist.</Typography>
+      ) : (
+        songsWithCharts.map(({ song }, index) => (
+          <Box key={song.id} sx={{ mb: 4, pageBreakInside: 'avoid' }}>
+            <Typography variant="h6" fontWeight={700} sx={{ mb: 1 }}>
+              {index + 1}. {song.name}
+              {song.artist ? ` — ${song.artist}` : ''}
+            </Typography>
+            <ChordChartViewer chordChart={song.chord_chart!} />
+            {index < songsWithCharts.length - 1 && <Divider sx={{ mt: 3 }} />}
+          </Box>
+        ))
+      )}
+    </>
+  );
+}

--- a/components/setlistEditor/SetlistEditor.tsx
+++ b/components/setlistEditor/SetlistEditor.tsx
@@ -10,6 +10,7 @@ import Hidden from '@mui/material/Hidden';
 import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import PrintIcon from '@mui/icons-material/Print';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
@@ -214,9 +215,20 @@ export default function SetlistEditor({
               <Button variant="contained" onClick={addSetlist}>
                 Add Set
               </Button>
-              <Button variant="contained" onClick={saveSetlist}>
-                Save Setlist
-              </Button>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                {setlist.id && (
+                  <Button
+                    variant="outlined"
+                    startIcon={<PrintIcon />}
+                    onClick={() => window.open(`/print/setlist/${setlist.id}/chord-charts`, '_blank')}
+                  >
+                    Print Chord Charts
+                  </Button>
+                )}
+                <Button variant="contained" onClick={saveSetlist}>
+                  Save Setlist
+                </Button>
+              </Box>
             </Box>
           </Grid>
           <Grid item xs={12} sm={6}>

--- a/hooks/useSetlistWithSongs.ts
+++ b/hooks/useSetlistWithSongs.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { createClient } from '@/utils/supabase/client';
+import { Tables } from '@/types/supabase';
+import { PostgrestError, useQuery } from '@supabase-cache-helpers/postgrest-swr';
+import { useMemo } from 'react';
+
+interface SetlistSongWithSong extends Tables<'setlist_songs'> {
+  songs: Tables<'songs'>;
+}
+
+interface SetlistWithSongs extends Tables<'setlists'> {
+  setlist_songs: SetlistSongWithSong[];
+}
+
+interface UseSetlistWithSongsProps {
+  setlistId: number;
+}
+
+interface UseSetlistWithSongsResult {
+  data?: SetlistWithSongs | null;
+  isLoading: boolean;
+  error?: PostgrestError;
+}
+
+export type { SetlistWithSongs, SetlistSongWithSong };
+
+export default function useSetlistWithSongs({ setlistId }: UseSetlistWithSongsProps): UseSetlistWithSongsResult {
+  const supabase = createClient();
+
+  const query = useMemo(
+    () =>
+      supabase
+        .from('setlists')
+        .select('*, setlist_songs(*, songs(*))')
+        .eq('id', setlistId)
+        .maybeSingle(),
+    [setlistId, supabase]
+  );
+
+  const { data, isLoading, error } = useQuery<SetlistWithSongs>(query, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
+
+  return { data, isLoading, error };
+}


### PR DESCRIPTION
## Summary
- Adds a **Print Chord Charts** button to the setlists list page (in the actions column) and to the setlist editor toolbar
- Clicking the button opens a new tab at `/print/setlist/[setlistId]/chord-charts`
- The print page shows all songs in the setlist (ordered by set, then position), each with its song name and chord chart — skipping songs with no chord chart
- The page hides the app header/footer on screen and when printing
- A **Print** button on the page triggers `window.print()`; the button is hidden during printing via `@media print`

## Test plan
- [ ] Open a setlist's edit page — verify "Print Chord Charts" button appears (only when setlist has been saved)
- [ ] Open the setlists list page — verify "Print Chord Charts" button appears in the actions column for each setlist
- [ ] Click the button — verify a new tab opens showing the chord charts in setlist order
- [ ] Verify songs without chord charts are excluded
- [ ] Use browser print (Cmd+P or the Print button) — verify header, footer, and Print button are hidden in print preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)