### PR TITLE
Merge chord chart field into add/edit song forms

### DIFF
--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -52,19 +52,6 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
     return <Loading />;
   }
 
-  function formatChordChart(_value: TablePropsDataType | null, row: TableRow) {
-    return (
-      <Button
-        component={Link}
-        href={`/band/${bandId}/songs/${row.id}/chord-chart`}
-        size="small"
-        variant="outlined"
-      >
-        View / Edit
-      </Button>
-    );
-  }
-
   let pageContent: JSX.Element;
 
   if (songs?.length) {
@@ -130,12 +117,6 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
           dataKey: 'commentsCount',
           className: 'whitespace-nowrap',
           dataFormatter: formatComments,
-        },
-        {
-          name: 'Chord Chart',
-          dataKey: 'id',
-          className: 'whitespace-nowrap',
-          dataFormatter: formatChordChart,
         },
         {
           name: '',

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -3,6 +3,7 @@
 import Loading from '@/components/design/Loading';
 import Table, { TableProps, TablePropsDataType, TableRow } from '@/components/design/Table';
 import AddSongModal from '@/components/modals/AddSongModal';
+import ChordChartViewModal from '@/components/modals/ChordChartViewModal';
 import EditSongModal from '@/components/modals/EditSongModal';
 import SongCommentsModal from '@/components/modals/SongCommentsModal';
 import useSongs, { SongsComposite } from '@/hooks/useSongs';
@@ -44,6 +45,11 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
     });
   }
 
+  function formatChordChart(value: TablePropsDataType | null, row: TableRow) {
+    if (!value) return null;
+    return <ChordChartViewModal songName={row.name as string | null} chordChart={value as string} />;
+  }
+
   function formatActions(_value: TablePropsDataType | null, row: TableRow) {
     return <EditSongModal song={row as unknown as SongsComposite} onSuccess={mutate} />;
   }
@@ -60,6 +66,7 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
       name: song.name,
       artist: song.artist,
       duration: song.duration,
+      chord_chart: song.chord_chart,
       commentsCount: song.song_comments[0].count,
     }));
 
@@ -117,6 +124,12 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
           dataKey: 'commentsCount',
           className: 'whitespace-nowrap',
           dataFormatter: formatComments,
+        },
+        {
+          name: 'Chord Chart',
+          dataKey: 'chord_chart',
+          className: 'whitespace-nowrap',
+          dataFormatter: formatChordChart,
         },
         {
           name: '',

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -46,7 +46,7 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
   }
 
   function formatChordChart(value: TablePropsDataType | null, row: TableRow) {
-    if (!value) return null;
+    if (!value) return '';
     return <ChordChartViewModal songName={row.name as string | null} chordChart={value as string} />;
   }
 

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -42,6 +42,14 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
         placeholder: 'e.g. 3:45',
         fullWidth: true,
       },
+      {
+        fieldType: 'textarea' as FormField['fieldType'],
+        name: 'chord_chart',
+        label: 'Chord Chart',
+        fullWidth: true,
+        rows: 10,
+        inputProps: { style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } },
+      },
     ],
     []
   );
@@ -59,6 +67,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
       name: data.name,
       artist: data.artist || null,
       duration,
+      chord_chart: data.chord_chart || null,
       band_id: bandId,
     });
 

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -50,6 +50,14 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
         placeholder: 'e.g. 3:45',
         fullWidth: true,
       },
+      {
+        fieldType: 'textarea' as FormField['fieldType'],
+        name: 'chord_chart',
+        label: 'Chord Chart',
+        fullWidth: true,
+        rows: 10,
+        inputProps: { style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } },
+      },
     ],
     []
   );
@@ -59,6 +67,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
       name: song.name ?? '',
       artist: song.artist ?? '',
       duration: song.duration ? formatMsToDuration(song.duration) : '',
+      chord_chart: song.chord_chart ?? '',
     }),
     [song]
   );
@@ -78,6 +87,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
         name: data.name,
         artist: data.artist || null,
         duration,
+        chord_chart: data.chord_chart || null,
       })
       .eq('id', song.id);
 

--- a/components/modals/AddSongModal.tsx
+++ b/components/modals/AddSongModal.tsx
@@ -23,7 +23,7 @@ export default function AddSongModal({ bandId, onSuccess }: Readonly<AddSongModa
       <Button variant="contained" onClick={() => setOpen(true)}>
         Add Song
       </Button>
-      <Dialog open={open} onClose={() => setOpen(false)}>
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="md" fullWidth>
         <DialogTitle>Add Song</DialogTitle>
         <DialogContent className="pt-3">
           <AddSongForm bandId={bandId} onSuccess={handleSuccess} />

--- a/components/modals/ChordChartViewModal.tsx
+++ b/components/modals/ChordChartViewModal.tsx
@@ -1,0 +1,35 @@
+import ChordChartViewer from '@/components/ChordChartViewer';
+import MusicNoteIcon from '@mui/icons-material/MusicNote';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import { useState } from 'react';
+
+interface ChordChartViewModalProps {
+  songName: string | null;
+  chordChart: string;
+}
+
+export default function ChordChartViewModal({ songName, chordChart }: Readonly<ChordChartViewModalProps>) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        size="small"
+        variant="outlined"
+        startIcon={<MusicNoteIcon />}
+        onClick={() => setOpen(true)}
+      >
+        View Chords
+      </Button>
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="md" fullWidth>
+        <DialogTitle>{songName ?? 'Chord Chart'}</DialogTitle>
+        <DialogContent>
+          <ChordChartViewer chordChart={chordChart} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/modals/EditSongModal.tsx
+++ b/components/modals/EditSongModal.tsx
@@ -25,7 +25,7 @@ export default function EditSongModal({ song, onSuccess }: Readonly<EditSongModa
       <IconButton aria-label="Edit song" size="small" onClick={() => setOpen(true)}>
         <EditIcon fontSize="small" />
       </IconButton>
-      <Dialog open={open} onClose={() => setOpen(false)}>
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="md" fullWidth>
         <DialogTitle>Edit Song</DialogTitle>
         <DialogContent className="pt-3">
           <EditSongForm song={song} onSuccess={handleSuccess} />


### PR DESCRIPTION
Adds the chord_chart textarea to AddSongForm and EditSongForm so users can
manage the chord chart directly from the song modal. Removes the separate
"Chord Chart" column/link from the songs table. Widens both modals to md
to accommodate the larger textarea.

https://claude.ai/code/session_013LVLaCTf6d9UufoMR42HjL