### PR TITLE
fix: prevent users from seeing band invitations sent to others

### DIFF
--- a/hooks/useMyInvitations.ts
+++ b/hooks/useMyInvitations.ts
@@ -17,21 +17,23 @@ interface UseMyInvitationsResult {
 
 export default function useMyInvitations(): UseMyInvitationsResult {
   const supabase = createClient();
-  const [userId, setUserId] = useState<string>('');
+  const [userId, setUserId] = useState<string | null>(null);
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
-      setUserId(data.user?.id ?? '');
+      setUserId(data.user?.id ?? null);
     });
   }, [supabase]);
 
   const query = useMemo(
     () =>
-      supabase
-        .from('band_invitations')
-        .select('*, bands(name)')
-        .eq('status', 'pending')
-        .eq('invitee_user_id', userId),
+      userId
+        ? supabase
+            .from('band_invitations')
+            .select('*, bands(name)')
+            .eq('status', 'pending')
+            .eq('invitee_user_id', userId)
+        : null,
     [supabase, userId]
   );
 

--- a/supabase/migrations/20240113000000_fix_invitations_rls.sql
+++ b/supabase/migrations/20240113000000_fix_invitations_rls.sql
@@ -1,0 +1,11 @@
+-- Fix overly permissive SELECT policy on band_invitations.
+-- Previously, any band member could see all pending invitations for their band,
+-- which exposed invitations sent to other people.
+-- Now only the invitee can see their own invitations.
+
+drop policy if exists "users can view relevant invitations" on public.band_invitations;
+
+create policy "invitees can view their own invitations"
+  on public.band_invitations for select
+  to authenticated
+  using (auth.uid() = invitee_user_id);


### PR DESCRIPTION
## Summary

- **RLS policy too permissive**: The SELECT policy on `band_invitations` allowed any band member to read all pending invitations for their bands (`auth.uid() = invitee_user_id OR is_band_member(band_id)`), exposing invitations sent to other people. A new migration drops that policy and replaces it with one scoped strictly to the invitee.
- **Race condition in `useMyInvitations`**: `userId` was initialised as `''` and the query fired immediately before auth resolved. An empty-string filter on a UUID column has undefined behaviour at the PostgREST level. Changed the initial state to `null` and the query is now skipped entirely (passes `null` to `useQuery`) until the real user ID is available.

## What a reviewer should know

- The migration (`20240113000000_fix_invitations_rls.sql`) needs to be applied to the Supabase instance. The old policy is dropped; the new one is `using (auth.uid() = invitee_user_id)` only.
- `useBandInvitations` (used for band management views) will now return empty results for band members who aren't the invitee, since the permissive RLS clause is gone. If a band admin "pending invitations" management view is needed in the future, a separate policy restricted to band owners/admins should be added at that time.

## Test plan

- [ ] Log in as User A who is already a member of Band X
- [ ] Invite User B to Band X
- [ ] While still logged in as User A, confirm the "Pending Invitations" section does NOT show the invite sent to User B
- [ ] Log in as User B and confirm the invite IS visible and can be accepted/declined
- [ ] Confirm no regressions on accept/decline flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)