### PR TITLE
Replace setlists action buttons with sticky actions menu

### DIFF
--- a/app/band/[bandId]/setlists/page.tsx
+++ b/app/band/[bandId]/setlists/page.tsx
@@ -7,9 +7,13 @@ import useSetlists from '@/hooks/useSetlists';
 import useSongs from '@/hooks/useSongs';
 import { TablesInsert } from '@/types/supabase';
 import { createClient } from '@/utils/supabase/client';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
@@ -19,9 +23,67 @@ import prettyMilliseconds from 'pretty-ms';
 import { useCallback, useMemo, useState } from 'react';
 import { BandRouteProps } from '../types';
 
+function SetlistActionsMenu({
+  setlistId,
+  bandId,
+  onDuplicate,
+}: {
+  setlistId: number;
+  bandId: string;
+  onDuplicate: (id: number) => void;
+}) {
+  const router = useRouter();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleOpen = (e: React.MouseEvent<HTMLElement>) => setAnchorEl(e.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+
+  return (
+    <>
+      <IconButton onClick={handleOpen} aria-label="actions" size="small">
+        <MoreVertIcon />
+      </IconButton>
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        <MenuItem
+          onClick={() => {
+            router.push(`/band/${bandId}/practice?setlist=${setlistId}`);
+            handleClose();
+          }}
+        >
+          Practice
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            router.push(`/band/${bandId}/setlists/${setlistId}/edit`);
+            handleClose();
+          }}
+        >
+          Edit
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            onDuplicate(setlistId);
+            handleClose();
+          }}
+        >
+          Duplicate
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            window.open(`/print/setlist/${setlistId}/chord-charts`, '_blank');
+            handleClose();
+          }}
+        >
+          Print Chord Charts
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}
+
 export default function BandSetlistsPage({ params }: Readonly<BandRouteProps>) {
   const { bandId } = params;
-  const router = useRouter();
 
   const [showPast, setShowPast] = useState(false);
   const [nameFilter, setNameFilter] = useState('');
@@ -91,35 +153,14 @@ export default function BandSetlistsPage({ params }: Readonly<BandRouteProps>) {
   const formatEditButton = useCallback(
     (setlistId: TablePropsDataType) => {
       return (
-        <Box sx={{ display: 'flex', gap: 1 }}>
-          <Button
-            variant="outlined"
-            onClick={() => router.push(`/band/${bandId}/practice?setlist=${setlistId}`)}
-          >
-            Practice
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={() => router.push(`/band/${bandId}/setlists/${setlistId}/edit`)}
-          >
-            Edit
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={() => duplicateSetlist(setlistId as number)}
-          >
-            Duplicate
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={() => window.open(`/print/setlist/${setlistId}/chord-charts`, '_blank')}
-          >
-            Print Chord Charts
-          </Button>
-        </Box>
+        <SetlistActionsMenu
+          setlistId={setlistId as number}
+          bandId={bandId}
+          onDuplicate={duplicateSetlist}
+        />
       );
     },
-    [bandId, router, duplicateSetlist]
+    [bandId, duplicateSetlist]
   );
 
   const isLoading = useMemo(() => {
@@ -192,7 +233,7 @@ export default function BandSetlistsPage({ params }: Readonly<BandRouteProps>) {
         { name: 'Name', dataKey: 'name', isHeader: true, headerDataKey: 'id' },
         { name: 'Date', dataKey: 'date', dataFormatter: formatDate },
         { name: 'Sets', dataKey: 'sets', dataFormatter: formatSets },
-        { name: 'Actions', dataKey: 'id', dataFormatter: formatEditButton },
+        { name: 'Actions', dataKey: 'id', dataFormatter: formatEditButton, stickyRight: true },
       ],
       rows: setlistsAdaptedForTable,
     };

--- a/app/band/[bandId]/setlists/page.tsx
+++ b/app/band/[bandId]/setlists/page.tsx
@@ -29,7 +29,7 @@ function SetlistActionsMenu({
   onDuplicate,
 }: {
   setlistId: number;
-  bandId: string;
+  bandId: number;
   onDuplicate: (id: number) => void;
 }) {
   const router = useRouter();

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -117,7 +117,7 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
 
   function formatActions(_value: TablePropsDataType | null, row: TableRow) {
     const song = songs?.find((s) => s.id === row.id);
-    if (!song) return null;
+    if (!song) return '';
     return <SongActionsMenu song={song} onEditSuccess={mutate} />;
   }
 

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -1,30 +1,100 @@
 'use client';
 
+import ChordChartViewer from '@/components/ChordChartViewer';
 import Loading from '@/components/design/Loading';
 import Table, { TableProps, TablePropsDataType, TableRow } from '@/components/design/Table';
+import EditSongForm from '@/components/forms/EditSongForm';
+import SongCommentForm from '@/components/forms/SongCommentForm';
 import AddSongModal from '@/components/modals/AddSongModal';
-import ChordChartViewModal from '@/components/modals/ChordChartViewModal';
-import EditSongModal from '@/components/modals/EditSongModal';
-import SongCommentsModal from '@/components/modals/SongCommentsModal';
 import useSongs, { SongsComposite } from '@/hooks/useSongs';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import Link from 'next/link';
 import prettyMilliseconds from 'pretty-ms';
 import { useState } from 'react';
 import { BandRouteProps } from '../types';
 
+function SongActionsMenu({
+  song,
+  onEditSuccess,
+}: {
+  song: SongsComposite;
+  onEditSuccess: () => void;
+}) {
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [activeModal, setActiveModal] = useState<'edit' | 'comments' | 'chords' | null>(null);
+
+  const menuOpen = Boolean(menuAnchor);
+  const commentsCount = song.song_comments[0].count;
+  const hasChordChart = Boolean(song.chord_chart);
+
+  const openMenu = (e: React.MouseEvent<HTMLElement>) => setMenuAnchor(e.currentTarget);
+  const closeMenu = () => setMenuAnchor(null);
+  const openModal = (modal: 'edit' | 'comments' | 'chords') => {
+    closeMenu();
+    setActiveModal(modal);
+  };
+  const closeModal = () => setActiveModal(null);
+
+  return (
+    <>
+      <IconButton onClick={openMenu} aria-label="actions" size="small">
+        <MoreVertIcon />
+      </IconButton>
+      <Menu anchorEl={menuAnchor} open={menuOpen} onClose={closeMenu}>
+        <MenuItem onClick={() => openModal('comments')}>
+          Comments ({commentsCount})
+        </MenuItem>
+        {hasChordChart && (
+          <MenuItem onClick={() => openModal('chords')}>View Chord Chart</MenuItem>
+        )}
+        <MenuItem onClick={() => openModal('edit')}>Edit</MenuItem>
+      </Menu>
+
+      <Dialog open={activeModal === 'edit'} onClose={closeModal} maxWidth="md" fullWidth>
+        <DialogTitle>Edit Song</DialogTitle>
+        <DialogContent className="pt-3">
+          <EditSongForm
+            song={song}
+            onSuccess={() => {
+              closeModal();
+              onEditSuccess();
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={activeModal === 'comments'} onClose={closeModal} maxWidth="md" fullWidth>
+        <DialogTitle>{song.name} Comments</DialogTitle>
+        <DialogContent>
+          <SongCommentForm songId={song.id} />
+        </DialogContent>
+      </Dialog>
+
+      {hasChordChart && (
+        <Dialog open={activeModal === 'chords'} onClose={closeModal} maxWidth="md" fullWidth>
+          <DialogTitle>{song.name ?? 'Chord Chart'}</DialogTitle>
+          <DialogContent>
+            <ChordChartViewer chordChart={song.chord_chart!} />
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
+  );
+}
+
 function formatDuration(value?: TablePropsDataType | null) {
   return value && typeof value === 'number'
     ? prettyMilliseconds(value, { secondsDecimalDigits: 0 })
     : '--';
-}
-
-function formatComments(value: TablePropsDataType | null, row: TableRow) {
-  return (
-    <SongCommentsModal commentsCount={+(value ?? 0)} song={row as unknown as SongsComposite} />
-  );
 }
 
 export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
@@ -45,13 +115,10 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
     });
   }
 
-  function formatChordChart(value: TablePropsDataType | null, row: TableRow) {
-    if (!value) return '';
-    return <ChordChartViewModal songName={row.name as string | null} chordChart={value as string} />;
-  }
-
   function formatActions(_value: TablePropsDataType | null, row: TableRow) {
-    return <EditSongModal song={row as unknown as SongsComposite} onSuccess={mutate} />;
+    const song = songs?.find((s) => s.id === row.id);
+    if (!song) return null;
+    return <SongActionsMenu song={song} onEditSuccess={mutate} />;
   }
 
   if (isLoading) {
@@ -66,8 +133,6 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
       name: song.name,
       artist: song.artist,
       duration: song.duration,
-      chord_chart: song.chord_chart,
-      commentsCount: song.song_comments[0].count,
     }));
 
     const q = searchQuery.toLowerCase();
@@ -120,22 +185,10 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
           onSort: () => handleSort('duration'),
         },
         {
-          name: 'Comments',
-          dataKey: 'commentsCount',
-          className: 'whitespace-nowrap',
-          dataFormatter: formatComments,
-        },
-        {
-          name: 'Chord Chart',
-          dataKey: 'chord_chart',
-          className: 'whitespace-nowrap',
-          dataFormatter: formatChordChart,
-        },
-        {
-          name: '',
+          name: 'Actions',
           dataKey: 'id',
           dataFormatter: formatActions,
-          className: 'whitespace-nowrap',
+          stickyRight: true,
         },
       ],
       rows: songsForTable,

--- a/components/design/Table.tsx
+++ b/components/design/Table.tsx
@@ -26,6 +26,7 @@ interface TableProps {
     sortable?: boolean;
     sortDirection?: 'asc' | 'desc';
     onSort?: () => void;
+    stickyRight?: boolean;
   }[];
   rows: TableRow[];
 }
@@ -48,8 +49,11 @@ export default function Table({ ariaLabel, columns, rows }: Readonly<TableProps>
       <MUITable aria-label="Table of Songs">
         <TableHead>
           <TableRow>
-            {columns.map(({ name, sortable, sortDirection, onSort }) => (
-              <TableCell key={name}>
+            {columns.map(({ name, sortable, sortDirection, onSort, stickyRight }) => (
+              <TableCell
+                key={name}
+                sx={stickyRight ? { position: 'sticky', right: 0, backgroundColor: 'background.paper', zIndex: 2 } : undefined}
+              >
                 {sortable ? (
                   <TableSortLabel
                     active={sortDirection !== undefined}
@@ -70,7 +74,7 @@ export default function Table({ ariaLabel, columns, rows }: Readonly<TableProps>
             return (
               <TableRow key={row[headerColumn.headerDataKey ?? '']}>
                 {columns.map(
-                  ({ name, dataKey, dataFormatter, isHeader, headerDataKey, className }) => {
+                  ({ name, dataKey, dataFormatter, isHeader, headerDataKey, className, stickyRight }) => {
                     let component: TableCellProps['component'] = 'td';
                     let scope: TableCellProps['scope'];
                     let value: TablePropsDataType | JSX.Element = row[dataKey];
@@ -90,6 +94,7 @@ export default function Table({ ariaLabel, columns, rows }: Readonly<TableProps>
                         scope={scope}
                         key={name}
                         className={className}
+                        sx={stickyRight ? { position: 'sticky', right: 0, backgroundColor: 'background.paper', zIndex: 1 } : undefined}
                       >
                         {value}
                       </TableCell>


### PR DESCRIPTION
Condenses the four action buttons (Practice, Edit, Duplicate, Print Chord
Charts) in the setlists table into a MoreVert icon button that opens a
dropdown menu. Adds stickyRight column support to the shared Table component
so the Actions column stays pinned when the table requires horizontal scroll.

https://claude.ai/code/session_01Sx4Hfsd8J4RR4LiY2xg9PF