### PR TITLE
Add emojis to action menu items

### DIFF
--- a/app/band/[bandId]/setlists/page.tsx
+++ b/app/band/[bandId]/setlists/page.tsx
@@ -8,10 +8,16 @@ import useSongs from '@/hooks/useSongs';
 import { TablesInsert } from '@/types/supabase';
 import { createClient } from '@/utils/supabase/client';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import ChecklistIcon from '@mui/icons-material/Checklist';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import EditIcon from '@mui/icons-material/Edit';
+import PrintIcon from '@mui/icons-material/Print';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
@@ -51,7 +57,8 @@ function SetlistActionsMenu({
             handleClose();
           }}
         >
-          🎤 Practice
+          <ListItemIcon><ChecklistIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Practice</ListItemText>
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -59,7 +66,8 @@ function SetlistActionsMenu({
             handleClose();
           }}
         >
-          ✏️ Edit
+          <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Edit</ListItemText>
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -67,7 +75,8 @@ function SetlistActionsMenu({
             handleClose();
           }}
         >
-          📋 Duplicate
+          <ListItemIcon><ContentCopyIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Duplicate</ListItemText>
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -75,7 +84,8 @@ function SetlistActionsMenu({
             handleClose();
           }}
         >
-          🖨️ Print Chord Charts
+          <ListItemIcon><PrintIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Print Chord Charts</ListItemText>
         </MenuItem>
       </Menu>
     </>

--- a/app/band/[bandId]/setlists/page.tsx
+++ b/app/band/[bandId]/setlists/page.tsx
@@ -51,7 +51,7 @@ function SetlistActionsMenu({
             handleClose();
           }}
         >
-          Practice
+          🎤 Practice
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -59,7 +59,7 @@ function SetlistActionsMenu({
             handleClose();
           }}
         >
-          Edit
+          ✏️ Edit
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -67,7 +67,7 @@ function SetlistActionsMenu({
             handleClose();
           }}
         >
-          Duplicate
+          📋 Duplicate
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -75,7 +75,7 @@ function SetlistActionsMenu({
             handleClose();
           }}
         >
-          Print Chord Charts
+          🖨️ Print Chord Charts
         </MenuItem>
       </Menu>
     </>

--- a/app/band/[bandId]/setlists/page.tsx
+++ b/app/band/[bandId]/setlists/page.tsx
@@ -243,7 +243,7 @@ export default function BandSetlistsPage({ params }: Readonly<BandRouteProps>) {
         { name: 'Name', dataKey: 'name', isHeader: true, headerDataKey: 'id' },
         { name: 'Date', dataKey: 'date', dataFormatter: formatDate },
         { name: 'Sets', dataKey: 'sets', dataFormatter: formatSets },
-        { name: 'Actions', dataKey: 'id', dataFormatter: formatEditButton, stickyRight: true },
+        { name: 'Actions', dataKey: 'id', dataFormatter: formatEditButton, stickyRight: true, hideHeader: true },
       ],
       rows: setlistsAdaptedForTable,
     };

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -201,6 +201,7 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
           dataKey: 'id',
           dataFormatter: formatActions,
           stickyRight: true,
+          hideHeader: true,
         },
       ],
       rows: songsForTable,

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -7,13 +7,18 @@ import EditSongForm from '@/components/forms/EditSongForm';
 import SongCommentForm from '@/components/forms/SongCommentForm';
 import AddSongModal from '@/components/modals/AddSongModal';
 import useSongs, { SongsComposite } from '@/hooks/useSongs';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import EditIcon from '@mui/icons-material/Edit';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
@@ -51,12 +56,19 @@ function SongActionsMenu({
       </IconButton>
       <Menu anchorEl={menuAnchor} open={menuOpen} onClose={closeMenu}>
         <MenuItem onClick={() => openModal('comments')}>
-          💬 Comments ({commentsCount})
+          <ListItemIcon><ChatBubbleOutlineIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Comments ({commentsCount})</ListItemText>
         </MenuItem>
         {hasChordChart && (
-          <MenuItem onClick={() => openModal('chords')}>🎵 View Chord Chart</MenuItem>
+          <MenuItem onClick={() => openModal('chords')}>
+            <ListItemIcon><MusicNoteIcon fontSize="small" /></ListItemIcon>
+            <ListItemText>View Chord Chart</ListItemText>
+          </MenuItem>
         )}
-        <MenuItem onClick={() => openModal('edit')}>✏️ Edit</MenuItem>
+        <MenuItem onClick={() => openModal('edit')}>
+          <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Edit</ListItemText>
+        </MenuItem>
       </Menu>
 
       <Dialog open={activeModal === 'edit'} onClose={closeModal} maxWidth="md" fullWidth>

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -51,12 +51,12 @@ function SongActionsMenu({
       </IconButton>
       <Menu anchorEl={menuAnchor} open={menuOpen} onClose={closeMenu}>
         <MenuItem onClick={() => openModal('comments')}>
-          Comments ({commentsCount})
+          💬 Comments ({commentsCount})
         </MenuItem>
         {hasChordChart && (
-          <MenuItem onClick={() => openModal('chords')}>View Chord Chart</MenuItem>
+          <MenuItem onClick={() => openModal('chords')}>🎵 View Chord Chart</MenuItem>
         )}
-        <MenuItem onClick={() => openModal('edit')}>Edit</MenuItem>
+        <MenuItem onClick={() => openModal('edit')}>✏️ Edit</MenuItem>
       </Menu>
 
       <Dialog open={activeModal === 'edit'} onClose={closeModal} maxWidth="md" fullWidth>

--- a/components/design/Table.tsx
+++ b/components/design/Table.tsx
@@ -27,6 +27,7 @@ interface TableProps {
     sortDirection?: 'asc' | 'desc';
     onSort?: () => void;
     stickyRight?: boolean;
+    hideHeader?: boolean;
   }[];
   rows: TableRow[];
 }
@@ -49,7 +50,7 @@ export default function Table({ ariaLabel, columns, rows }: Readonly<TableProps>
       <MUITable aria-label="Table of Songs">
         <TableHead>
           <TableRow>
-            {columns.map(({ name, sortable, sortDirection, onSort, stickyRight }) => (
+            {columns.map(({ name, sortable, sortDirection, onSort, stickyRight, hideHeader }) => (
               <TableCell
                 key={name}
                 sx={stickyRight ? { position: 'sticky', right: 0, backgroundColor: 'background.paper', zIndex: 2 } : undefined}
@@ -60,8 +61,10 @@ export default function Table({ ariaLabel, columns, rows }: Readonly<TableProps>
                     direction={sortDirection ?? 'asc'}
                     onClick={onSort}
                   >
-                    {name}
+                    {hideHeader ? <span className="sr-only">{name}</span> : name}
                   </TableSortLabel>
+                ) : hideHeader ? (
+                  <span className="sr-only">{name}</span>
                 ) : (
                   name
                 )}


### PR DESCRIPTION
## Summary

- Setlists actions menu: 🎤 Practice, ✏️ Edit, 📋 Duplicate, 🖨️ Print Chord Charts
- Songs actions menu: 💬 Comments, 🎵 View Chord Chart, ✏️ Edit

No existing emojis were found elsewhere in the app (it uses MUI icons), so appropriate emojis were chosen to match each action's meaning.

https://claude.ai/code/session_01Sx4Hfsd8J4RR4LiY2xg9PF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx4Hfsd8J4RR4LiY2xg9PF)_