### PR TITLE
Replace band nav cards with left sidebar

### DIFF
--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -79,7 +79,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
           sx={{
             width: 200,
             flexShrink: 0,
-            bgcolor: 'background.paper',
+            bgcolor: '#fef2f2',
             borderRight: '1px solid',
             borderColor: 'divider',
             pt: 3,

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -5,6 +5,7 @@ import BandBreadcrumbs from '@/components/layout/BandBreadcrumbs';
 import useBand from '@/hooks/useBand';
 import ArchiveIcon from '@mui/icons-material/Archive';
 import ChecklistIcon from '@mui/icons-material/Checklist';
+import GridViewIcon from '@mui/icons-material/GridView';
 import GroupIcon from '@mui/icons-material/Group';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
 import QueueMusicIcon from '@mui/icons-material/QueueMusic';
@@ -54,11 +55,14 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
       }
     };
 
+    const basePath = `/band/${bandId}`;
+
     const navItems = [
-      { label: 'Members', href: `/band/${bandId}/members`, icon: <GroupIcon fontSize="small" /> },
-      { label: 'Songs', href: `/band/${bandId}/songs`, icon: <LibraryMusicIcon fontSize="small" /> },
-      { label: 'Setlists', href: `/band/${bandId}/setlists`, icon: <QueueMusicIcon fontSize="small" /> },
-      { label: 'Practice', href: `/band/${bandId}/practice`, icon: <ChecklistIcon fontSize="small" /> },
+      { label: 'Overview', href: basePath, icon: <GridViewIcon fontSize="small" />, exact: true },
+      { label: 'Members', href: `${basePath}/members`, icon: <GroupIcon fontSize="small" /> },
+      { label: 'Songs', href: `${basePath}/songs`, icon: <LibraryMusicIcon fontSize="small" /> },
+      { label: 'Setlists', href: `${basePath}/setlists`, icon: <QueueMusicIcon fontSize="small" /> },
+      { label: 'Practice', href: `${basePath}/practice`, icon: <ChecklistIcon fontSize="small" /> },
     ];
 
     return (
@@ -88,7 +92,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
         >
           <List disablePadding>
             {navItems.map((item) => {
-              const isActive = pathname.startsWith(item.href);
+              const isActive = item.exact ? pathname === item.href : pathname.startsWith(item.href);
               return (
                 <ListItem key={item.href} disablePadding>
                   <ListItemButton

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -158,18 +158,21 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
 
         <Box sx={{ flex: 1, minWidth: 0, pt: 3, pb: 2, pl: { xs: 2, sm: 3 }, pr: { xs: 2, sm: '0.75rem' } }}>
           {/* Mobile menu toggle + breadcrumbs row */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <IconButton
               onClick={() => setMobileOpen(true)}
               size="small"
-              sx={{ display: { sm: 'none' }, mr: 0.5 }}
+              sx={{ display: { sm: 'none' }, mr: 0.5, flexShrink: 0 }}
               aria-label="Open navigation menu"
             >
               <MenuIcon fontSize="small" />
             </IconButton>
-            <BandBreadcrumbs bandId={bandId} bandName={band.name} />
+            {/* Wrapper zeroes out the mb:2 on MuiBreadcrumbs so it doesn't offset flex centering */}
+            <Box sx={{ '& .MuiBreadcrumbs-root': { mb: 0 } }}>
+              <BandBreadcrumbs bandId={bandId} bandName={band.name} />
+            </Box>
           </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap', mt: 2 }}>
             <Typography variant="h4" fontWeight={700} color="text.primary">
               {band.name}
             </Typography>

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -66,13 +66,14 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
     ];
 
     return (
-      // Negative margins break out of the root layout's p-3 container padding so the
-      // sidebar background and border extend flush to the app header and page edges.
+      // Breaks out of the root layout's max-w-4xl centered container and p-3 padding.
+      // calc(50% - 50vw - 0.75rem) shifts left by: half the centering gap + the padding.
       <Box
         sx={{
           display: 'flex',
           alignItems: 'stretch',
-          mx: '-0.75rem',
+          width: '100vw',
+          ml: 'calc(50% - 50vw - 0.75rem)',
           mt: '-0.75rem',
           mb: '-0.75rem',
           minHeight: 'calc(100vh - 64px)',

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -62,8 +62,63 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
     ];
 
     return (
-      <>
-        <Box sx={{ pt: 3, pb: 2 }}>
+      // Negative margins break out of the root layout's p-3 container padding so the
+      // sidebar background and border extend flush to the app header and page edges.
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'stretch',
+          mx: '-0.75rem',
+          mt: '-0.75rem',
+          mb: '-0.75rem',
+          minHeight: 'calc(100vh - 64px)',
+        }}
+      >
+        <Box
+          component="nav"
+          sx={{
+            width: 200,
+            flexShrink: 0,
+            bgcolor: 'background.paper',
+            borderRight: '1px solid',
+            borderColor: 'divider',
+            pt: 3,
+            px: 1.5,
+          }}
+        >
+          <List disablePadding>
+            {navItems.map((item) => {
+              const isActive = pathname.startsWith(item.href);
+              return (
+                <ListItem key={item.href} disablePadding>
+                  <ListItemButton
+                    component={NextLink}
+                    href={item.href}
+                    selected={isActive}
+                    sx={{
+                      borderRadius: 1,
+                      mb: 0.5,
+                      '&.Mui-selected': {
+                        bgcolor: 'primary.main',
+                        color: 'primary.contrastText',
+                        '& .MuiListItemIcon-root': { color: 'primary.contrastText' },
+                        '&:hover': { bgcolor: 'primary.dark' },
+                      },
+                    }}
+                  >
+                    <ListItemIcon sx={{ minWidth: 36 }}>{item.icon}</ListItemIcon>
+                    <ListItemText
+                      primary={item.label}
+                      primaryTypographyProps={{ variant: 'body2' }}
+                    />
+                  </ListItemButton>
+                </ListItem>
+              );
+            })}
+          </List>
+        </Box>
+
+        <Box sx={{ flex: 1, minWidth: 0, pt: 3, pb: 2, pl: 3, pr: '0.75rem' }}>
           <BandBreadcrumbs bandId={bandId} bandName={band.name} />
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
             <Typography variant="h4" fontWeight={700} color="text.primary">
@@ -86,53 +141,10 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
               </Button>
             </Box>
           </Box>
-          <Divider sx={{ mt: 2 }} />
+          <Divider sx={{ mt: 2, mb: 3 }} />
+          {children}
         </Box>
-        <Box sx={{ display: 'flex', gap: 3 }}>
-          <Box
-            component="nav"
-            sx={{
-              width: 200,
-              flexShrink: 0,
-              borderRight: '1px solid',
-              borderColor: 'divider',
-              pr: 1,
-            }}
-          >
-            <List disablePadding>
-              {navItems.map((item) => {
-                const isActive = pathname.startsWith(item.href);
-                return (
-                  <ListItem key={item.href} disablePadding>
-                    <ListItemButton
-                      component={NextLink}
-                      href={item.href}
-                      selected={isActive}
-                      sx={{
-                        borderRadius: 1,
-                        mb: 0.5,
-                        '&.Mui-selected': {
-                          bgcolor: 'primary.main',
-                          color: 'primary.contrastText',
-                          '& .MuiListItemIcon-root': { color: 'primary.contrastText' },
-                          '&:hover': { bgcolor: 'primary.dark' },
-                        },
-                      }}
-                    >
-                      <ListItemIcon sx={{ minWidth: 36 }}>{item.icon}</ListItemIcon>
-                      <ListItemText
-                        primary={item.label}
-                        primaryTypographyProps={{ variant: 'body2' }}
-                      />
-                    </ListItemButton>
-                  </ListItem>
-                );
-              })}
-            </List>
-          </Box>
-          <Box sx={{ flex: 1, minWidth: 0 }}>{children}</Box>
-        </Box>
-      </>
+      </Box>
     );
   }
 

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -4,13 +4,23 @@ import Loading from '@/components/design/Loading';
 import BandBreadcrumbs from '@/components/layout/BandBreadcrumbs';
 import useBand from '@/hooks/useBand';
 import ArchiveIcon from '@mui/icons-material/Archive';
+import ChecklistIcon from '@mui/icons-material/Checklist';
+import GroupIcon from '@mui/icons-material/Group';
+import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
+import QueueMusicIcon from '@mui/icons-material/QueueMusic';
 import UnarchiveIcon from '@mui/icons-material/Unarchive';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
-import { useRouter } from 'next/navigation';
+import NextLink from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
 import { ReactNode, useState } from 'react';
 import { BandRouteProps } from './types';
 
@@ -25,6 +35,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
   const { data: band, isLoading } = useBand({ bandId });
   const [archiving, setArchiving] = useState(false);
   const router = useRouter();
+  const pathname = usePathname();
 
   if (isLoading) {
     return <Loading />;
@@ -42,6 +53,13 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
         setArchiving(false);
       }
     };
+
+    const navItems = [
+      { label: 'Members', href: `/band/${bandId}/members`, icon: <GroupIcon fontSize="small" /> },
+      { label: 'Songs', href: `/band/${bandId}/songs`, icon: <LibraryMusicIcon fontSize="small" /> },
+      { label: 'Setlists', href: `/band/${bandId}/setlists`, icon: <QueueMusicIcon fontSize="small" /> },
+      { label: 'Practice', href: `/band/${bandId}/practice`, icon: <ChecklistIcon fontSize="small" /> },
+    ];
 
     return (
       <>
@@ -70,7 +88,50 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
           </Box>
           <Divider sx={{ mt: 2 }} />
         </Box>
-        <Box>{children}</Box>
+        <Box sx={{ display: 'flex', gap: 3 }}>
+          <Box
+            component="nav"
+            sx={{
+              width: 200,
+              flexShrink: 0,
+              borderRight: '1px solid',
+              borderColor: 'divider',
+              pr: 1,
+            }}
+          >
+            <List disablePadding>
+              {navItems.map((item) => {
+                const isActive = pathname.startsWith(item.href);
+                return (
+                  <ListItem key={item.href} disablePadding>
+                    <ListItemButton
+                      component={NextLink}
+                      href={item.href}
+                      selected={isActive}
+                      sx={{
+                        borderRadius: 1,
+                        mb: 0.5,
+                        '&.Mui-selected': {
+                          bgcolor: 'primary.main',
+                          color: 'primary.contrastText',
+                          '& .MuiListItemIcon-root': { color: 'primary.contrastText' },
+                          '&:hover': { bgcolor: 'primary.dark' },
+                        },
+                      }}
+                    >
+                      <ListItemIcon sx={{ minWidth: 36 }}>{item.icon}</ListItemIcon>
+                      <ListItemText
+                        primary={item.label}
+                        primaryTypographyProps={{ variant: 'body2' }}
+                      />
+                    </ListItemButton>
+                  </ListItem>
+                );
+              })}
+            </List>
+          </Box>
+          <Box sx={{ flex: 1, minWidth: 0 }}>{children}</Box>
+        </Box>
       </>
     );
   }

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -8,12 +8,15 @@ import ChecklistIcon from '@mui/icons-material/Checklist';
 import GridViewIcon from '@mui/icons-material/GridView';
 import GroupIcon from '@mui/icons-material/Group';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
+import MenuIcon from '@mui/icons-material/Menu';
 import QueueMusicIcon from '@mui/icons-material/QueueMusic';
 import UnarchiveIcon from '@mui/icons-material/Unarchive';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -31,10 +34,13 @@ interface ConsumerProps {
 
 type BandLayoutProps = BandRouteProps & ConsumerProps;
 
+const SIDEBAR_WIDTH = 200;
+
 export default function BandLayout({ children, params }: BandLayoutProps) {
   const { bandId } = params;
   const { data: band, isLoading } = useBand({ bandId });
   const [archiving, setArchiving] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
 
@@ -65,6 +71,40 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
       { label: 'Practice', href: `${basePath}/practice`, icon: <ChecklistIcon fontSize="small" /> },
     ];
 
+    const navList = (onNavigate?: () => void) => (
+      <List disablePadding>
+        {navItems.map((item) => {
+          const isActive = item.exact ? pathname === item.href : pathname.startsWith(item.href);
+          return (
+            <ListItem key={item.href} disablePadding>
+              <ListItemButton
+                component={NextLink}
+                href={item.href}
+                selected={isActive}
+                onClick={onNavigate}
+                sx={{
+                  borderRadius: 1,
+                  mb: 0.5,
+                  '&.Mui-selected': {
+                    bgcolor: 'primary.main',
+                    color: 'primary.contrastText',
+                    '& .MuiListItemIcon-root': { color: 'primary.contrastText' },
+                    '&:hover': { bgcolor: 'primary.dark' },
+                  },
+                }}
+              >
+                <ListItemIcon sx={{ minWidth: 36 }}>{item.icon}</ListItemIcon>
+                <ListItemText
+                  primary={item.label}
+                  primaryTypographyProps={{ variant: 'body2' }}
+                />
+              </ListItemButton>
+            </ListItem>
+          );
+        })}
+      </List>
+    );
+
     return (
       // Breaks out of the root layout's max-w-4xl centered container and p-3 padding.
       // calc(50% - 50vw - 0.75rem) shifts left by: half the centering gap + the padding.
@@ -79,10 +119,12 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
           minHeight: 'calc(100vh - 64px)',
         }}
       >
+        {/* Permanent sidebar — desktop only */}
         <Box
           component="nav"
           sx={{
-            width: 200,
+            display: { xs: 'none', sm: 'block' },
+            width: SIDEBAR_WIDTH,
             flexShrink: 0,
             bgcolor: '#fef2f2',
             borderRight: '1px solid',
@@ -91,40 +133,42 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
             px: 1.5,
           }}
         >
-          <List disablePadding>
-            {navItems.map((item) => {
-              const isActive = item.exact ? pathname === item.href : pathname.startsWith(item.href);
-              return (
-                <ListItem key={item.href} disablePadding>
-                  <ListItemButton
-                    component={NextLink}
-                    href={item.href}
-                    selected={isActive}
-                    sx={{
-                      borderRadius: 1,
-                      mb: 0.5,
-                      '&.Mui-selected': {
-                        bgcolor: 'primary.main',
-                        color: 'primary.contrastText',
-                        '& .MuiListItemIcon-root': { color: 'primary.contrastText' },
-                        '&:hover': { bgcolor: 'primary.dark' },
-                      },
-                    }}
-                  >
-                    <ListItemIcon sx={{ minWidth: 36 }}>{item.icon}</ListItemIcon>
-                    <ListItemText
-                      primary={item.label}
-                      primaryTypographyProps={{ variant: 'body2' }}
-                    />
-                  </ListItemButton>
-                </ListItem>
-              );
-            })}
-          </List>
+          {navList()}
         </Box>
 
-        <Box sx={{ flex: 1, minWidth: 0, pt: 3, pb: 2, pl: 3, pr: '0.75rem' }}>
-          <BandBreadcrumbs bandId={bandId} bandName={band.name} />
+        {/* Temporary drawer — mobile only */}
+        <Drawer
+          variant="temporary"
+          open={mobileOpen}
+          onClose={() => setMobileOpen(false)}
+          ModalProps={{ keepMounted: true }}
+          sx={{
+            display: { xs: 'block', sm: 'none' },
+            '& .MuiDrawer-paper': {
+              width: SIDEBAR_WIDTH,
+              bgcolor: '#fef2f2',
+              pt: 3,
+              px: 1.5,
+              boxSizing: 'border-box',
+            },
+          }}
+        >
+          {navList(() => setMobileOpen(false))}
+        </Drawer>
+
+        <Box sx={{ flex: 1, minWidth: 0, pt: 3, pb: 2, pl: { xs: 2, sm: 3 }, pr: { xs: 2, sm: '0.75rem' } }}>
+          {/* Mobile menu toggle + breadcrumbs row */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0 }}>
+            <IconButton
+              onClick={() => setMobileOpen(true)}
+              size="small"
+              sx={{ display: { sm: 'none' }, mr: 0.5 }}
+              aria-label="Open navigation menu"
+            >
+              <MenuIcon fontSize="small" />
+            </IconButton>
+            <BandBreadcrumbs bandId={bandId} bandName={band.name} />
+          </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
             <Typography variant="h4" fontWeight={700} color="text.primary">
               {band.name}

--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -1,63 +1,10 @@
 'use client';
 
 import BandEventsCalendar from '@/components/BandEventsCalendar';
-import Card, { CardProps } from '@/components/design/Card';
-import ResponsiveGrid from '@/components/design/ResponsiveGrid';
-import ChecklistIcon from '@mui/icons-material/Checklist';
-import GroupIcon from '@mui/icons-material/Group';
-import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
-import QueueMusicIcon from '@mui/icons-material/QueueMusic';
-import Divider from '@mui/material/Divider';
-import { useMemo } from 'react';
 import { BandRouteProps } from './types';
 
 export default function BandDashboardPage({ params }: Readonly<BandRouteProps>): JSX.Element {
   const { bandId } = params;
 
-  const actions: Required<Omit<CardProps, 'className' | 'variant'>>[] = useMemo(
-    () => [
-      {
-        title: 'Manage Members',
-        description: "Who's in the band?",
-        link: `/band/${bandId}/members`,
-        icon: <GroupIcon />,
-      },
-      {
-        title: 'Manage Songs',
-        description: 'What songs do you play?',
-        link: `/band/${bandId}/songs`,
-        icon: <LibraryMusicIcon />,
-      },
-      {
-        title: 'Manage Setlists',
-        description: 'What are you playing at your gigs?',
-        link: `/band/${bandId}/setlists`,
-        icon: <QueueMusicIcon />,
-      },
-      {
-        title: 'Practice',
-        description: 'Track your readiness for the next gig.',
-        link: `/band/${bandId}/practice`,
-        icon: <ChecklistIcon />,
-      },
-    ],
-    [bandId]
-  );
-
-  const cardClassName = 'md:basis-1/3 sm:basis-1/2 basis-full';
-
-  const responsiveGridItems = useMemo(() => {
-    return actions.map((action) => ({
-      key: action.link,
-      content: <Card {...action} className={cardClassName} variant="feature" />,
-    }));
-  }, [actions]);
-
-  return (
-    <>
-      <BandEventsCalendar bandId={bandId} />
-      <Divider sx={{ my: 3 }} />
-      <ResponsiveGrid items={responsiveGridItems} />
-    </>
-  );
+  return <BandEventsCalendar bandId={bandId} />;
 }

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 export default function Footer() {
   return (
     <footer className="w-full flex justify-center border-t h-16">
-      <div className="w-full max-w-4xl flex justify-between items-center p-3">
+      <div className="w-full flex justify-between items-center px-3">
         <Typography variant="caption" color="text.secondary">
           A{' '}
           <Link href="https://joshglazer.com" target="_blank" rel="noreferrer" underline="hover" color="inherit" fontWeight={600}>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,10 +1,21 @@
 import GitHubIcon from '@mui/icons-material/GitHub';
+import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 
 export default function Footer() {
   return (
-    <footer className="w-full flex justify-center border-t h-16">
+    <Box
+      component="footer"
+      sx={{
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        borderTop: '1px solid',
+        borderColor: 'divider',
+        height: 64,
+      }}
+    >
       <div className="w-full flex justify-between items-center px-3">
         <Typography variant="caption" color="text.secondary">
           A{' '}
@@ -24,6 +35,6 @@ export default function Footer() {
           <GitHubIcon sx={{ fontSize: 16 }} /> Source Code
         </Link>
       </div>
-    </footer>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a persistent left sidebar to the band layout with navigation links for Members, Songs, Setlists, and Practice
- Active sidebar item is highlighted in the primary color
- Removes the feature card grid from the band dashboard page, keeping just the events calendar as the landing view

## Test plan
- [ ] Click into a band and verify the left sidebar appears with all four nav items
- [ ] Navigate between Members, Songs, Setlists, and Practice and verify the active item highlights correctly
- [ ] Verify the events calendar still shows on the band dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)