### PR TITLE
Full-width band layout with responsive sidebar

### DIFF
--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -150,7 +150,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
           {navList(() => setMobileOpen(false))}
         </Drawer>
 
-        <Box sx={{ flex: 1, minWidth: 0, pt: 3, pb: 2, pl: { xs: 2, sm: 3 }, pr: { xs: 2, sm: '0.75rem' } }}>
+        <Box sx={{ flex: 1, minWidth: 0, pt: 3, pb: 2, pl: 3, pr: { xs: 3, sm: '0.75rem' } }}>
           <BandBreadcrumbs bandId={bandId} bandName={band.name} />
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
             <Typography variant="h4" fontWeight={700} color="text.primary">

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -2,13 +2,13 @@
 
 import Loading from '@/components/design/Loading';
 import BandBreadcrumbs from '@/components/layout/BandBreadcrumbs';
+import { useNav } from '@/components/layout/NavContext';
 import useBand from '@/hooks/useBand';
 import ArchiveIcon from '@mui/icons-material/Archive';
 import ChecklistIcon from '@mui/icons-material/Checklist';
 import GridViewIcon from '@mui/icons-material/GridView';
 import GroupIcon from '@mui/icons-material/Group';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
-import MenuIcon from '@mui/icons-material/Menu';
 import QueueMusicIcon from '@mui/icons-material/QueueMusic';
 import UnarchiveIcon from '@mui/icons-material/Unarchive';
 import Box from '@mui/material/Box';
@@ -16,7 +16,6 @@ import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
-import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -35,12 +34,13 @@ interface ConsumerProps {
 type BandLayoutProps = BandRouteProps & ConsumerProps;
 
 const SIDEBAR_WIDTH = 200;
+const SIDEBAR_BG = { light: '#fef2f2', dark: '#1a0b0d' };
 
 export default function BandLayout({ children, params }: BandLayoutProps) {
   const { bandId } = params;
   const { data: band, isLoading } = useBand({ bandId });
   const [archiving, setArchiving] = useState(false);
-  const [mobileOpen, setMobileOpen] = useState(false);
+  const { mobileOpen, setMobileOpen } = useNav();
   const router = useRouter();
   const pathname = usePathname();
 
@@ -105,6 +105,15 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
       </List>
     );
 
+    const sidebarSx = {
+      bgcolor: (theme: { palette: { mode: string } }) =>
+        theme.palette.mode === 'dark' ? SIDEBAR_BG.dark : SIDEBAR_BG.light,
+      borderRight: '1px solid',
+      borderColor: 'divider',
+      pt: 3,
+      px: 1.5,
+    };
+
     return (
       // Breaks out of the root layout's max-w-4xl centered container and p-3 padding.
       // calc(50% - 50vw - 0.75rem) shifts left by: half the centering gap + the padding.
@@ -122,16 +131,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
         {/* Permanent sidebar — desktop only */}
         <Box
           component="nav"
-          sx={{
-            display: { xs: 'none', sm: 'block' },
-            width: SIDEBAR_WIDTH,
-            flexShrink: 0,
-            bgcolor: '#fef2f2',
-            borderRight: '1px solid',
-            borderColor: 'divider',
-            pt: 3,
-            px: 1.5,
-          }}
+          sx={{ display: { xs: 'none', sm: 'block' }, width: SIDEBAR_WIDTH, flexShrink: 0, ...sidebarSx }}
         >
           {navList()}
         </Box>
@@ -144,35 +144,15 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
           ModalProps={{ keepMounted: true }}
           sx={{
             display: { xs: 'block', sm: 'none' },
-            '& .MuiDrawer-paper': {
-              width: SIDEBAR_WIDTH,
-              bgcolor: '#fef2f2',
-              pt: 3,
-              px: 1.5,
-              boxSizing: 'border-box',
-            },
+            '& .MuiDrawer-paper': { width: SIDEBAR_WIDTH, boxSizing: 'border-box', ...sidebarSx },
           }}
         >
           {navList(() => setMobileOpen(false))}
         </Drawer>
 
         <Box sx={{ flex: 1, minWidth: 0, pt: 3, pb: 2, pl: { xs: 2, sm: 3 }, pr: { xs: 2, sm: '0.75rem' } }}>
-          {/* Mobile menu toggle + breadcrumbs row */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <IconButton
-              onClick={() => setMobileOpen(true)}
-              size="small"
-              sx={{ display: { sm: 'none' }, mr: 0.5, flexShrink: 0 }}
-              aria-label="Open navigation menu"
-            >
-              <MenuIcon fontSize="small" />
-            </IconButton>
-            {/* Wrapper zeroes out the mb:2 on MuiBreadcrumbs so it doesn't offset flex centering */}
-            <Box sx={{ '& .MuiBreadcrumbs-root': { mb: 0 } }}>
-              <BandBreadcrumbs bandId={bandId} bandName={band.name} />
-            </Box>
-          </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap', mt: 2 }}>
+          <BandBreadcrumbs bandId={bandId} bandName={band.name} />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
             <Typography variant="h4" fontWeight={700} color="text.primary">
               {band.name}
             </Typography>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import Footer from '@/components/layout/Footer';
 import Header from '@/components/layout/Header';
+import { NavProvider } from '@/components/layout/NavContext';
 import ThemeRegistry from '@/components/ThemeRegistry';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
 import { GeistSans } from 'geist/font/sans';
@@ -27,13 +28,15 @@ export default function RootLayout({ children }: Readonly<RootLayoutProps>) {
       <html lang="en" className={GeistSans.className}>
         <body>
           <ThemeRegistry>
-            <div className="min-h-screen flex-1 w-full flex flex-col items-center">
-              <Header />
-              <main className="flex flex-col items-center grow w-full">
-                <div className="w-full max-w-4xl p-3">{children}</div>
-              </main>
-              <Footer />
-            </div>
+            <NavProvider>
+              <div className="min-h-screen flex-1 w-full flex flex-col items-center">
+                <Header />
+                <main className="flex flex-col items-center grow w-full">
+                  <div className="w-full max-w-4xl p-3">{children}</div>
+                </main>
+                <Footer />
+              </div>
+            </NavProvider>
           </ThemeRegistry>
         </body>
       </html>

--- a/components/design/ResponsiveGrid.tsx
+++ b/components/design/ResponsiveGrid.tsx
@@ -10,7 +10,7 @@ interface ResponsiveGridProps {
 
 export default function ResponsiveGrid({ items }: Readonly<ResponsiveGridProps>) {
   return (
-    <Grid container spacing={2} justifyContent="flex-start" alignItems="center">
+    <Grid container spacing={2} justifyContent="flex-start" alignItems="center" sx={{ mt: 0, ml: 0, width: '100%' }}>
       {items.map(({ key, content }) => (
         <Fragment key={key}>{content}</Fragment>
       ))}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -6,11 +6,13 @@ import Typography from '@mui/material/Typography';
 import Link from 'next/link';
 import { Suspense } from 'react';
 import AuthButton from './AuthButton';
+import HeaderNavToggle from './HeaderNavToggle';
 
 export default function Header() {
   return (
     <AppBar position="static" sx={{ width: '100%' }}>
       <Toolbar sx={{ maxWidth: '64rem', width: '100%', mx: 'auto', px: { xs: 2, sm: 3 } }}>
+        <HeaderNavToggle />
         <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
           <Link href="/" className="no-underline" style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'inherit' }}>
             <MusicNoteIcon sx={{ fontSize: 26 }} />

--- a/components/layout/HeaderNavToggle.tsx
+++ b/components/layout/HeaderNavToggle.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import MenuIcon from '@mui/icons-material/Menu';
+import IconButton from '@mui/material/IconButton';
+import { usePathname } from 'next/navigation';
+import { useNav } from './NavContext';
+
+export default function HeaderNavToggle() {
+  const pathname = usePathname();
+  const { setMobileOpen } = useNav();
+
+  if (!pathname.startsWith('/band/')) return null;
+
+  return (
+    <IconButton
+      onClick={() => setMobileOpen(true)}
+      size="small"
+      sx={{ display: { sm: 'none' }, color: 'inherit', mr: 1 }}
+      aria-label="Open navigation menu"
+    >
+      <MenuIcon />
+    </IconButton>
+  );
+}

--- a/components/layout/NavContext.tsx
+++ b/components/layout/NavContext.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+interface NavContextValue {
+  mobileOpen: boolean;
+  setMobileOpen: (open: boolean) => void;
+}
+
+const NavContext = createContext<NavContextValue>({
+  mobileOpen: false,
+  setMobileOpen: () => {},
+});
+
+export function NavProvider({ children }: { children: ReactNode }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  return <NavContext.Provider value={{ mobileOpen, setMobileOpen }}>{children}</NavContext.Provider>;
+}
+
+export function useNav() {
+  return useContext(NavContext);
+}


### PR DESCRIPTION
## Summary
- Band layout breaks out of the `max-w-4xl` container to fill the full viewport width
- Sidebar has a theme-aware warm tinted background and runs flush to the app header
- **Overview** link added to the top of the sidebar with exact-match active state
- On mobile, the sidebar is hidden by default; a hamburger button in the app header opens it as a temporary drawer that closes on navigation
- `NavContext` shares `mobileOpen` state between `Header` and `BandLayout` without prop drilling
- Footer stretched to full viewport width with a proper MUI divider border (fixes invisible `border-t` from Tailwind when MUI CssBaseline is active)
- Band dashboard page simplified to just the events calendar (nav cards replaced by the sidebar)

## Test plan
- [ ] Desktop: sidebar visible on all band pages, active item highlighted, full viewport width
- [ ] Mobile: no sidebar on load, hamburger in header opens drawer, tapping a link closes it
- [ ] Dark mode: sidebar uses dark background (`#1a0b0d`)
- [ ] Non-band pages (home, login): no hamburger icon in header
- [ ] Footer border visible across full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)