### PR TITLE
Add band settings page with rename and archive confirmation

### DIFF
--- a/app/api/bands/[bandId]/rename/route.ts
+++ b/app/api/bands/[bandId]/rename/route.ts
@@ -1,0 +1,37 @@
+import { createClient } from '@/utils/supabase/server';
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { bandId: string } }
+) {
+  const bandId = parseInt(params.bandId, 10);
+  if (!bandId) {
+    return NextResponse.json({ error: 'Invalid band ID' }, { status: 400 });
+  }
+
+  const { name } = await request.json();
+  if (!name || typeof name !== 'string' || !name.trim()) {
+    return NextResponse.json({ error: 'Name is required' }, { status: 400 });
+  }
+
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { error: updateError } = await supabase
+    .from('bands')
+    .update({ name: name.trim() })
+    .eq('id', bandId);
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ name: name.trim() });
+}

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -4,15 +4,13 @@ import Loading from '@/components/design/Loading';
 import BandBreadcrumbs from '@/components/layout/BandBreadcrumbs';
 import { useNav } from '@/components/layout/NavContext';
 import useBand from '@/hooks/useBand';
-import ArchiveIcon from '@mui/icons-material/Archive';
 import ChecklistIcon from '@mui/icons-material/Checklist';
 import GridViewIcon from '@mui/icons-material/GridView';
 import GroupIcon from '@mui/icons-material/Group';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
 import QueueMusicIcon from '@mui/icons-material/QueueMusic';
-import UnarchiveIcon from '@mui/icons-material/Unarchive';
+import SettingsIcon from '@mui/icons-material/Settings';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
@@ -23,8 +21,8 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
 import NextLink from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
-import { ReactNode, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { ReactNode } from 'react';
 import { BandRouteProps } from './types';
 
 interface ConsumerProps {
@@ -39,9 +37,7 @@ const SIDEBAR_BG = { light: '#fef2f2', dark: '#1a0b0d' };
 export default function BandLayout({ children, params }: BandLayoutProps) {
   const { bandId } = params;
   const { data: band, isLoading } = useBand({ bandId });
-  const [archiving, setArchiving] = useState(false);
   const { mobileOpen, setMobileOpen } = useNav();
-  const router = useRouter();
   const pathname = usePathname();
 
   if (isLoading) {
@@ -51,16 +47,6 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
   if (band) {
     const isArchived = !!band.archived_at;
 
-    const toggleArchive = async () => {
-      setArchiving(true);
-      try {
-        await fetch(`/api/bands/${bandId}/archive`, { method: 'POST' });
-        router.refresh();
-      } finally {
-        setArchiving(false);
-      }
-    };
-
     const basePath = `/band/${bandId}`;
 
     const navItems = [
@@ -69,6 +55,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
       { label: 'Songs', href: `${basePath}/songs`, icon: <LibraryMusicIcon fontSize="small" /> },
       { label: 'Setlists', href: `${basePath}/setlists`, icon: <QueueMusicIcon fontSize="small" /> },
       { label: 'Practice', href: `${basePath}/practice`, icon: <ChecklistIcon fontSize="small" /> },
+      { label: 'Settings', href: `${basePath}/settings`, icon: <SettingsIcon fontSize="small" /> },
     ];
 
     const navList = (onNavigate?: () => void) => (
@@ -159,19 +146,6 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
             {isArchived && (
               <Chip label="Archived" size="small" color="default" variant="outlined" />
             )}
-            <Box sx={{ ml: 'auto' }}>
-              <Button
-                size="small"
-                variant="text"
-                color="inherit"
-                startIcon={isArchived ? <UnarchiveIcon /> : <ArchiveIcon />}
-                onClick={toggleArchive}
-                disabled={archiving}
-                sx={{ color: 'text.secondary' }}
-              >
-                {isArchived ? 'Unarchive band' : 'Archive band'}
-              </Button>
-            </Box>
           </Box>
           <Divider sx={{ mt: 2, mb: 3 }} />
           {children}

--- a/app/band/[bandId]/settings/page.tsx
+++ b/app/band/[bandId]/settings/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import Loading from '@/components/design/Loading';
+import useBand from '@/hooks/useBand';
+import ArchiveIcon from '@mui/icons-material/Archive';
+import UnarchiveIcon from '@mui/icons-material/Unarchive';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { BandRouteProps } from '../types';
+
+export default function BandSettingsPage({ params }: Readonly<BandRouteProps>) {
+  const { bandId } = params;
+  const { data: band, isLoading } = useBand({ bandId });
+  const router = useRouter();
+
+  const [name, setName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [archiving, setArchiving] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  useEffect(() => {
+    if (band) setName(band.name);
+  }, [band]);
+
+  if (isLoading) return <Loading />;
+  if (!band) return <Typography variant="h5">Band not found.</Typography>;
+
+  const isArchived = !!band.archived_at;
+  const nameChanged = name.trim() !== band.name;
+
+  const handleRename = async () => {
+    if (!nameChanged) return;
+    setSaving(true);
+    try {
+      await fetch(`/api/bands/${bandId}/rename`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      router.refresh();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleArchive = async () => {
+    setConfirmOpen(false);
+    setArchiving(true);
+    try {
+      await fetch(`/api/bands/${bandId}/archive`, { method: 'POST' });
+      router.refresh();
+    } finally {
+      setArchiving(false);
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: 560 }}>
+      <Typography variant="h6" fontWeight={600} gutterBottom>
+        Band Name
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+        <TextField
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          size="small"
+          fullWidth
+          inputProps={{ maxLength: 100 }}
+        />
+        <Button
+          variant="contained"
+          onClick={handleRename}
+          disabled={!nameChanged || saving || !name.trim()}
+          sx={{ whiteSpace: 'nowrap' }}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </Box>
+
+      <Divider sx={{ my: 4 }} />
+
+      <Typography variant="h6" fontWeight={600} color="error" gutterBottom>
+        Danger Zone
+      </Typography>
+      <Box
+        sx={{
+          border: '1px solid',
+          borderColor: 'error.main',
+          borderRadius: 1,
+          p: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box>
+          <Typography variant="body2" fontWeight={600}>
+            {isArchived ? 'Unarchive this band' : 'Archive this band'}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {isArchived
+              ? 'Restore this band and make it active again.'
+              : 'Hide this band from your active bands list.'}
+          </Typography>
+        </Box>
+        <Button
+          variant="outlined"
+          color={isArchived ? 'inherit' : 'error'}
+          startIcon={isArchived ? <UnarchiveIcon /> : <ArchiveIcon />}
+          onClick={isArchived ? handleArchive : () => setConfirmOpen(true)}
+          disabled={archiving}
+        >
+          {isArchived ? 'Unarchive band' : 'Archive band'}
+        </Button>
+      </Box>
+
+      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <DialogTitle>Archive band?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to archive <strong>{band.name}</strong>? It will be hidden from
+            your active bands list. You can unarchive it at any time from the settings page.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)}>Cancel</Button>
+          <Button onClick={handleArchive} color="error" variant="contained" disabled={archiving}>
+            Archive band
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/components/layout/BandBreadcrumbs.tsx
+++ b/components/layout/BandBreadcrumbs.tsx
@@ -19,6 +19,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   edit: 'Edit Setlist',
   'spotify-import': 'Import from Spotify',
   practice: 'Practice',
+  settings: 'Settings',
 };
 
 export default function BandBreadcrumbs({ bandId, bandName }: BandBreadcrumbsProps) {


### PR DESCRIPTION
## Summary

- Adds a new **Settings** page (`/band/[id]/settings`) to each band with:
  - **Band Name** — inline text field + Save button to rename the band
  - **Danger Zone** — archive/unarchive button with a confirmation modal before archiving
- Moves the archive button out of the band layout header and onto the settings page
- Adds a `PATCH /api/bands/[bandId]/rename` endpoint
- Adds Settings to the sidebar nav and the breadcrumb label map

## Test plan

- [ ] Navigate to a band → confirm archive button is gone from the header
- [ ] Click Settings in the sidebar → verify the settings page loads
- [ ] Rename a band — save is disabled when name is unchanged, enables when edited, refreshes header name after save
- [ ] Click Archive band → confirm modal appears; Cancel dismisses it; Archive button archives and shows "Archived" chip
- [ ] Unarchive a band from the settings page (no modal needed for unarchive)
- [ ] Breadcrumb shows "Settings" when on the settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)