### PR TITLE
fix: correct band layout breakout margin to center content on mobile

### DIFF
--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -103,13 +103,14 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
 
     return (
       // Breaks out of the root layout's max-w-4xl centered container and p-3 padding.
-      // calc(50% - 50vw - 0.75rem) shifts left by: half the centering gap + the padding.
+      // With border-box sizing, 50% of the content width equals exactly the offset needed
+      // to reach the viewport left edge (centering gap + padding are both captured by 50% - 50vw).
       <Box
         sx={{
           display: 'flex',
           alignItems: 'stretch',
           width: '100vw',
-          ml: 'calc(50% - 50vw - 0.75rem)',
+          ml: 'calc(50% - 50vw)',
           mt: '-0.75rem',
           mb: '-0.75rem',
           minHeight: 'calc(100vh - 64px)',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,8 +31,8 @@ export default function RootLayout({ children }: Readonly<RootLayoutProps>) {
             <NavProvider>
               <div className="min-h-screen flex-1 w-full flex flex-col">
                 <Header />
-                <main className="flex flex-col items-center grow w-full">
-                  <div className="w-full max-w-4xl p-3">{children}</div>
+                <main className="flex flex-col grow w-full">
+                  <div className="w-full max-w-4xl mx-auto p-3">{children}</div>
                 </main>
                 <Footer />
               </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({ children }: Readonly<RootLayoutProps>) {
         <body>
           <ThemeRegistry>
             <NavProvider>
-              <div className="min-h-screen flex-1 w-full flex flex-col items-center">
+              <div className="min-h-screen flex-1 w-full flex flex-col">
                 <Header />
                 <main className="flex flex-col items-center grow w-full">
                   <div className="w-full max-w-4xl p-3">{children}</div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default async function IndexPage() {
       {user ? (
         <>
           <PendingInvitations />
-          <Typography variant="h5" fontWeight={700} mb={3}>
+          <Typography variant="h5" fontWeight={700} mt={2} mb={3} ml={1.5}>
             Your Bands
           </Typography>
           <Bands />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default async function IndexPage() {
       {user ? (
         <>
           <PendingInvitations />
-          <Typography variant="h5" fontWeight={700} mt={2} mb={3} ml={1.5}>
+          <Typography variant="h5" sx={{ fontWeight: 700, mt: 3, mb: 2, ml: 1.5 }}>
             Your Bands
           </Typography>
           <Bands />

--- a/components/Bands.tsx
+++ b/components/Bands.tsx
@@ -107,7 +107,7 @@ export default function Bands() {
       </Box>
       {showArchived && (
         <Box sx={{ mt: 4 }}>
-          <Typography variant="h6" fontWeight={600} mb={2} color="text.secondary">
+          <Typography variant="h6" sx={{ fontWeight: 600, mb: 2, ml: 1.5, color: 'text.secondary' }}>
             Archived Bands
           </Typography>
           <BandList includeArchived={true} />

--- a/components/Bands.tsx
+++ b/components/Bands.tsx
@@ -34,7 +34,7 @@ function BandList({ includeArchived }: { includeArchived: boolean }) {
   }
 
   return (
-    <Grid container spacing={2} justifyContent="flex-start" alignItems="stretch">
+    <Grid container justifyContent="flex-start" alignItems="stretch">
       {data.map(({ id, name, song_count, member_count }) => {
         const bandCardDescription = (
           <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -11,7 +11,7 @@ import HeaderNavToggle from './HeaderNavToggle';
 export default function Header() {
   return (
     <AppBar position="static" sx={{ width: '100%' }}>
-      <Toolbar sx={{ maxWidth: '64rem', width: '100%', mx: 'auto', px: { xs: 2, sm: 3 } }}>
+      <Toolbar sx={{ width: '100%', px: { xs: 2, sm: 3 } }}>
         <HeaderNavToggle />
         <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
           <Link href="/" className="no-underline" style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'inherit' }}>


### PR DESCRIPTION
The ml formula was shifted 0.75rem too far left. With border-box sizing,
calc(50% - 50vw) already captures both the centering offset and the padding,
so the extra - 0.75rem caused content to appear closer to the left edge and
prevented the layout from reaching the right viewport edge in landscape.

https://claude.ai/code/session_01V4xAAbdnS4fZWcH1XFXAzA