### PR TITLE
Add Events page and next-gig countdown on Overview

### DIFF
--- a/app/band/[bandId]/events/page.tsx
+++ b/app/band/[bandId]/events/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import BandEventsCalendar from '@/components/BandEventsCalendar';
+import { BandRouteProps } from '../types';
+
+export default function BandEventsPage({ params }: Readonly<BandRouteProps>): JSX.Element {
+  const { bandId } = params;
+  return <BandEventsCalendar bandId={bandId} />;
+}

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -4,6 +4,7 @@ import Loading from '@/components/design/Loading';
 import BandBreadcrumbs from '@/components/layout/BandBreadcrumbs';
 import { useNav } from '@/components/layout/NavContext';
 import useBand from '@/hooks/useBand';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import ChecklistIcon from '@mui/icons-material/Checklist';
 import GridViewIcon from '@mui/icons-material/GridView';
 import GroupIcon from '@mui/icons-material/Group';
@@ -51,6 +52,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
 
     const navItems = [
       { label: 'Overview', href: basePath, icon: <GridViewIcon fontSize="small" />, exact: true },
+      { label: 'Events', href: `${basePath}/events`, icon: <CalendarMonthIcon fontSize="small" /> },
       { label: 'Members', href: `${basePath}/members`, icon: <GroupIcon fontSize="small" /> },
       { label: 'Songs', href: `${basePath}/songs`, icon: <LibraryMusicIcon fontSize="small" /> },
       { label: 'Setlists', href: `${basePath}/setlists`, icon: <QueueMusicIcon fontSize="small" /> },

--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -1,10 +1,189 @@
 'use client';
 
-import BandEventsCalendar from '@/components/BandEventsCalendar';
+import useBandEvents from '@/hooks/useBandEvents';
+import useSetlists from '@/hooks/useSetlists';
+import { BandEvent } from '@/types/composites';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import ChecklistIcon from '@mui/icons-material/Checklist';
+import MicIcon from '@mui/icons-material/Mic';
+import QueueMusicIcon from '@mui/icons-material/QueueMusic';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
+import NextLink from 'next/link';
+import { useMemo } from 'react';
 import { BandRouteProps } from './types';
+
+function todayDateStr(): string {
+  const t = new Date();
+  return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}-${String(t.getDate()).padStart(2, '0')}`;
+}
+
+function daysUntil(dateStr: string): number {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const target = new Date(year, month - 1, day);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return Math.round((target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function formatDate(dateStr: string, timeStr: string | null): string {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const d = new Date(year, month - 1, day);
+  const datePart = d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+  if (!timeStr) return datePart;
+  const [hours, minutes] = timeStr.split(':').map(Number);
+  const t = new Date(year, month - 1, day, hours, minutes);
+  return datePart + ' · ' + t.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+}
+
+interface NextGigCardProps {
+  gig: BandEvent;
+  bandId: number;
+  setlistId?: number;
+}
+
+function NextGigCard({ gig, bandId, setlistId }: NextGigCardProps) {
+  const days = daysUntil(gig.date);
+
+  let countdownLabel: string;
+  let countdownSub: string;
+  if (days === 0) {
+    countdownLabel = 'Today';
+    countdownSub = "It's gig day!";
+  } else if (days === 1) {
+    countdownLabel = '1';
+    countdownSub = 'day to go';
+  } else {
+    countdownLabel = String(days);
+    countdownSub = 'days to go';
+  }
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3, maxWidth: 480 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <MicIcon color="primary" />
+        <Typography variant="overline" color="primary" fontWeight={700} lineHeight={1}>
+          Next Gig
+        </Typography>
+      </Box>
+
+      {/* Countdown */}
+      <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, mb: 1 }}>
+        <Typography variant="h2" fontWeight={800} color="primary" lineHeight={1}>
+          {countdownLabel}
+        </Typography>
+        {days > 0 && (
+          <Typography variant="h6" color="text.secondary" fontWeight={400}>
+            {countdownSub}
+          </Typography>
+        )}
+      </Box>
+      {days === 0 && (
+        <Typography variant="h6" color="text.secondary" fontWeight={400} sx={{ mb: 1 }}>
+          {countdownSub}
+        </Typography>
+      )}
+
+      {/* Gig details */}
+      <Typography variant="body1" fontWeight={600} sx={{ mb: 0.5 }}>
+        {gig.location}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2.5 }}>
+        {formatDate(gig.date, gig.time)}
+      </Typography>
+
+      {/* Links */}
+      {setlistId !== undefined && (
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          <Button
+            component={NextLink}
+            href={`/band/${bandId}/setlists/${setlistId}/edit`}
+            variant="outlined"
+            size="small"
+            startIcon={<QueueMusicIcon />}
+          >
+            Setlist
+          </Button>
+          <Button
+            component={NextLink}
+            href={`/band/${bandId}/practice?setlist=${setlistId}`}
+            variant="outlined"
+            size="small"
+            startIcon={<ChecklistIcon />}
+          >
+            Practice
+          </Button>
+        </Box>
+      )}
+    </Paper>
+  );
+}
+
+function NoGigCard({ bandId }: { bandId: number }) {
+  return (
+    <Paper variant="outlined" sx={{ p: 3, maxWidth: 480 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        <CalendarMonthIcon color="disabled" />
+        <Typography variant="overline" color="text.secondary" fontWeight={700} lineHeight={1}>
+          No Upcoming Gigs
+        </Typography>
+      </Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Nothing scheduled yet. Add a gig to start the countdown.
+      </Typography>
+      <Button
+        component={NextLink}
+        href={`/band/${bandId}/events`}
+        variant="outlined"
+        size="small"
+        startIcon={<CalendarMonthIcon />}
+      >
+        View Events
+      </Button>
+    </Paper>
+  );
+}
 
 export default function BandDashboardPage({ params }: Readonly<BandRouteProps>): JSX.Element {
   const { bandId } = params;
+  const { data: events, isLoading: eventsLoading } = useBandEvents({ bandId });
+  const { data: setlists } = useSetlists({ bandId });
 
-  return <BandEventsCalendar bandId={bandId} />;
+  const today = useMemo(todayDateStr, []);
+
+  const setlistsByEventId = useMemo(() => {
+    const map = new Map<number, number>();
+    setlists?.forEach((s) => {
+      if (s.event_id) map.set(s.event_id, s.id);
+    });
+    return map;
+  }, [setlists]);
+
+  const nextGig = useMemo(
+    () => (events ?? []).find((e) => e.type === 'gig' && e.date >= today) ?? null,
+    [events, today]
+  );
+
+  if (eventsLoading) {
+    return (
+      <Box>
+        <Skeleton variant="rounded" width={480} height={180} />
+      </Box>
+    );
+  }
+
+  if (!nextGig) {
+    return <NoGigCard bandId={bandId} />;
+  }
+
+  return (
+    <NextGigCard
+      gig={nextGig}
+      bandId={bandId}
+      setlistId={setlistsByEventId.get(nextGig.id)}
+    />
+  );
 }

--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -5,15 +5,18 @@ import useSetlists from '@/hooks/useSetlists';
 import { BandEvent } from '@/types/composites';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import ChecklistIcon from '@mui/icons-material/Checklist';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import MicIcon from '@mui/icons-material/Mic';
 import QueueMusicIcon from '@mui/icons-material/QueueMusic';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
 import NextLink from 'next/link';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { BandRouteProps } from './types';
 
 function todayDateStr(): string {
@@ -39,13 +42,17 @@ function formatDate(dateStr: string, timeStr: string | null): string {
   return datePart + ' · ' + t.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
 }
 
-interface NextGigCardProps {
+interface GigCardProps {
   gig: BandEvent;
   bandId: number;
   setlistId?: number;
+  index: number;
+  total: number;
+  onPrev: () => void;
+  onNext: () => void;
 }
 
-function NextGigCard({ gig, bandId, setlistId }: NextGigCardProps) {
+function GigCard({ gig, bandId, setlistId, index, total, onPrev, onNext }: GigCardProps) {
   const days = daysUntil(gig.date);
 
   let countdownLabel: string;
@@ -61,13 +68,29 @@ function NextGigCard({ gig, bandId, setlistId }: NextGigCardProps) {
     countdownSub = 'days to go';
   }
 
+  const heading = index === 0 ? 'Next Gig' : `Upcoming Gig`;
+
   return (
     <Paper variant="outlined" sx={{ p: 3, maxWidth: 480 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-        <MicIcon color="primary" />
-        <Typography variant="overline" color="primary" fontWeight={700} lineHeight={1}>
-          Next Gig
+      {/* Header row: label + nav arrows */}
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+        <MicIcon color="primary" sx={{ mr: 1 }} />
+        <Typography variant="overline" color="primary" fontWeight={700} lineHeight={1} sx={{ flex: 1 }}>
+          {heading}
         </Typography>
+        {total > 1 && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <IconButton size="small" onClick={onPrev} disabled={index === 0} aria-label="Previous gig">
+              <ChevronLeftIcon fontSize="small" />
+            </IconButton>
+            <Typography variant="caption" color="text.secondary" sx={{ minWidth: 32, textAlign: 'center' }}>
+              {index + 1} / {total}
+            </Typography>
+            <IconButton size="small" onClick={onNext} disabled={index === total - 1} aria-label="Next gig">
+              <ChevronRightIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        )}
       </Box>
 
       {/* Countdown */}
@@ -151,6 +174,7 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
   const { bandId } = params;
   const { data: events, isLoading: eventsLoading } = useBandEvents({ bandId });
   const { data: setlists } = useSetlists({ bandId });
+  const [gigIndex, setGigIndex] = useState(0);
 
   const today = useMemo(todayDateStr, []);
 
@@ -162,8 +186,8 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
     return map;
   }, [setlists]);
 
-  const nextGig = useMemo(
-    () => (events ?? []).find((e) => e.type === 'gig' && e.date >= today) ?? null,
+  const upcomingGigs = useMemo(
+    () => (events ?? []).filter((e) => e.type === 'gig' && e.date >= today),
     [events, today]
   );
 
@@ -175,15 +199,22 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
     );
   }
 
-  if (!nextGig) {
+  if (upcomingGigs.length === 0) {
     return <NoGigCard bandId={bandId} />;
   }
 
+  const safeIndex = Math.min(gigIndex, upcomingGigs.length - 1);
+  const gig = upcomingGigs[safeIndex];
+
   return (
-    <NextGigCard
-      gig={nextGig}
+    <GigCard
+      gig={gig}
       bandId={bandId}
-      setlistId={setlistsByEventId.get(nextGig.id)}
+      setlistId={setlistsByEventId.get(gig.id)}
+      index={safeIndex}
+      total={upcomingGigs.length}
+      onPrev={() => setGigIndex((i) => Math.max(0, i - 1))}
+      onNext={() => setGigIndex((i) => Math.min(upcomingGigs.length - 1, i + 1))}
     />
   );
 }

--- a/components/layout/BandBreadcrumbs.tsx
+++ b/components/layout/BandBreadcrumbs.tsx
@@ -12,6 +12,7 @@ interface BandBreadcrumbsProps {
 }
 
 const SEGMENT_LABELS: Record<string, string> = {
+  events: 'Events',
   members: 'Members',
   songs: 'Songs',
   setlists: 'Setlists',


### PR DESCRIPTION
## Summary

- Moves the calendar/events listing to a dedicated **Events** page (`/band/[bandId]/events`) accessible from the sidebar
- Adds an **Events** nav item (calendar icon) to the band sidebar between Overview and Members
- Replaces the Overview page content with a **next-gig countdown** — shows the number of days until the next scheduled gig, with **Setlist** and **Practice** quick-link buttons when the gig has an associated setlist
- Shows a friendly "No Upcoming Gigs" state with a link to the Events page when none are scheduled
- Adds `events` to the breadcrumb segment labels

## Test plan

- [ ] Navigate to a band's Overview — should show countdown card or no-gig empty state
- [ ] If a gig exists with an associated setlist, Setlist and Practice buttons appear and link correctly
- [ ] Sidebar shows Events between Overview and Members
- [ ] Clicking Events in sidebar navigates to the full calendar/events view
- [ ] Breadcrumbs on Events page show Home > Band > Events

🤖 Generated with [Claude Code](https://claude.com/claude-code)