### PR TITLE
Add practice prompt block to overview page

### DIFF
--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import PracticePrompt from '@/components/PracticePrompt';
 import useBandEvents from '@/hooks/useBandEvents';
 import useSetlists from '@/hooks/useSetlists';
 import { BandEvent } from '@/types/composites';
@@ -191,30 +192,26 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
     [events, today]
   );
 
-  if (eventsLoading) {
-    return (
-      <Box>
-        <Skeleton variant="rounded" width={480} height={180} />
-      </Box>
-    );
-  }
-
-  if (upcomingGigs.length === 0) {
-    return <NoGigCard bandId={bandId} />;
-  }
-
-  const safeIndex = Math.min(gigIndex, upcomingGigs.length - 1);
-  const gig = upcomingGigs[safeIndex];
-
-  return (
+  const gigContent = eventsLoading ? (
+    <Skeleton variant="rounded" width={480} height={180} />
+  ) : upcomingGigs.length === 0 ? (
+    <NoGigCard bandId={bandId} />
+  ) : (
     <GigCard
-      gig={gig}
+      gig={upcomingGigs[Math.min(gigIndex, upcomingGigs.length - 1)]}
       bandId={bandId}
-      setlistId={setlistsByEventId.get(gig.id)}
-      index={safeIndex}
+      setlistId={setlistsByEventId.get(upcomingGigs[Math.min(gigIndex, upcomingGigs.length - 1)].id)}
+      index={Math.min(gigIndex, upcomingGigs.length - 1)}
       total={upcomingGigs.length}
       onPrev={() => setGigIndex((i) => Math.max(0, i - 1))}
       onNext={() => setGigIndex((i) => Math.min(upcomingGigs.length - 1, i + 1))}
     />
+  );
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <PracticePrompt bandId={bandId} />
+      {gigContent}
+    </Box>
   );
 }

--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -207,7 +207,7 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
   );
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 3, alignItems: { xs: 'flex-start', md: 'stretch' } }}>
+    <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 3, alignItems: 'stretch' }}>
       {gigContent}
       <PracticePrompt bandId={bandId} />
     </Box>

--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -209,7 +209,7 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
   );
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 3, alignItems: 'flex-start' }}>
+    <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 3, alignItems: { xs: 'flex-start', md: 'stretch' } }}>
       {gigContent}
       <PracticePrompt bandId={bandId} />
     </Box>

--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import BlockHeader from '@/components/design/BlockHeader';
 import PracticePrompt from '@/components/PracticePrompt';
 import useBandEvents from '@/hooks/useBandEvents';
 import useSetlists from '@/hooks/useSetlists';
@@ -69,30 +70,29 @@ function GigCard({ gig, bandId, setlistId, index, total, onPrev, onNext }: GigCa
     countdownSub = 'days to go';
   }
 
-  const heading = index === 0 ? 'Next Gig' : `Upcoming Gig`;
+  const heading = index === 0 ? 'Next Gig' : 'Upcoming Gig';
+
+  const navAction = total > 1 ? (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <IconButton size="small" onClick={onPrev} disabled={index === 0} aria-label="Previous gig">
+        <ChevronLeftIcon fontSize="small" />
+      </IconButton>
+      <Typography variant="caption" color="text.secondary" sx={{ minWidth: 32, textAlign: 'center' }}>
+        {index + 1} / {total}
+      </Typography>
+      <IconButton size="small" onClick={onNext} disabled={index === total - 1} aria-label="Next gig">
+        <ChevronRightIcon fontSize="small" />
+      </IconButton>
+    </Box>
+  ) : undefined;
 
   return (
     <Paper variant="outlined" sx={{ p: 3, flex: 1 }}>
-      {/* Header row: label + nav arrows */}
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-        <MicIcon color="primary" sx={{ mr: 1 }} />
-        <Typography variant="overline" color="primary" fontWeight={700} lineHeight={1} sx={{ flex: 1 }}>
-          {heading}
-        </Typography>
-        {total > 1 && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <IconButton size="small" onClick={onPrev} disabled={index === 0} aria-label="Previous gig">
-              <ChevronLeftIcon fontSize="small" />
-            </IconButton>
-            <Typography variant="caption" color="text.secondary" sx={{ minWidth: 32, textAlign: 'center' }}>
-              {index + 1} / {total}
-            </Typography>
-            <IconButton size="small" onClick={onNext} disabled={index === total - 1} aria-label="Next gig">
-              <ChevronRightIcon fontSize="small" />
-            </IconButton>
-          </Box>
-        )}
-      </Box>
+      <BlockHeader
+        icon={<MicIcon color="primary" />}
+        title={heading}
+        action={navAction}
+      />
 
       {/* Countdown */}
       <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, mb: 1 }}>
@@ -149,12 +149,10 @@ function GigCard({ gig, bandId, setlistId, index, total, onPrev, onNext }: GigCa
 function NoGigCard({ bandId }: { bandId: number }) {
   return (
     <Paper variant="outlined" sx={{ p: 3, flex: 1 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
-        <CalendarMonthIcon color="disabled" />
-        <Typography variant="overline" color="text.secondary" fontWeight={700} lineHeight={1}>
-          No Upcoming Gigs
-        </Typography>
-      </Box>
+      <BlockHeader
+        icon={<CalendarMonthIcon color="disabled" />}
+        title="No Upcoming Gigs"
+      />
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         Nothing scheduled yet. Add a gig to start the countdown.
       </Typography>

--- a/app/band/[bandId]/page.tsx
+++ b/app/band/[bandId]/page.tsx
@@ -72,7 +72,7 @@ function GigCard({ gig, bandId, setlistId, index, total, onPrev, onNext }: GigCa
   const heading = index === 0 ? 'Next Gig' : `Upcoming Gig`;
 
   return (
-    <Paper variant="outlined" sx={{ p: 3, maxWidth: 480 }}>
+    <Paper variant="outlined" sx={{ p: 3, flex: 1 }}>
       {/* Header row: label + nav arrows */}
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
         <MicIcon color="primary" sx={{ mr: 1 }} />
@@ -148,7 +148,7 @@ function GigCard({ gig, bandId, setlistId, index, total, onPrev, onNext }: GigCa
 
 function NoGigCard({ bandId }: { bandId: number }) {
   return (
-    <Paper variant="outlined" sx={{ p: 3, maxWidth: 480 }}>
+    <Paper variant="outlined" sx={{ p: 3, flex: 1 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
         <CalendarMonthIcon color="disabled" />
         <Typography variant="overline" color="text.secondary" fontWeight={700} lineHeight={1}>
@@ -193,7 +193,7 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
   );
 
   const gigContent = eventsLoading ? (
-    <Skeleton variant="rounded" width={480} height={180} />
+    <Skeleton variant="rounded" sx={{ flex: 1 }} height={180} />
   ) : upcomingGigs.length === 0 ? (
     <NoGigCard bandId={bandId} />
   ) : (
@@ -209,9 +209,9 @@ export default function BandDashboardPage({ params }: Readonly<BandRouteProps>):
   );
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      <PracticePrompt bandId={bandId} />
+    <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 3, alignItems: 'flex-start' }}>
       {gigContent}
+      <PracticePrompt bandId={bandId} />
     </Box>
   );
 }

--- a/components/PracticePrompt.tsx
+++ b/components/PracticePrompt.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import usePracticeProgress from '@/hooks/usePracticeProgress';
+import useSongs, { SongsComposite } from '@/hooks/useSongs';
+import { createClient } from '@/utils/supabase/client';
+import CasinoIcon from '@mui/icons-material/Casino';
+import MusicNoteIcon from '@mui/icons-material/MusicNote';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type PracticeStatus = 'not_ready' | 'passable' | 'ready';
+
+const STATUS_LABEL: Record<PracticeStatus, string> = {
+  not_ready: 'Not Ready',
+  passable: 'Passable',
+  ready: 'Ready',
+};
+
+const STATUS_COLOR: Record<PracticeStatus, 'error' | 'warning' | 'success'> = {
+  not_ready: 'error',
+  passable: 'warning',
+  ready: 'success',
+};
+
+function pickRandom<T>(arr: T[], exclude?: T): T {
+  if (arr.length === 1) return arr[0];
+  const candidates = exclude !== undefined ? arr.filter((x) => x !== exclude) : arr;
+  return candidates[Math.floor(Math.random() * candidates.length)];
+}
+
+interface PracticePromptProps {
+  bandId: number;
+}
+
+export default function PracticePrompt({ bandId }: PracticePromptProps) {
+  const { data: songs, isLoading: songsLoading } = useSongs({ bandId });
+  const { data: practiceRows, isLoading: progressLoading, mutate } = usePracticeProgress({ bandId });
+  const [pickedSongId, setPickedSongId] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<{ open: boolean; severity: 'success' | 'error'; message: string }>({
+    open: false,
+    severity: 'success',
+    message: '',
+  });
+
+  const statusBySongId = useMemo(() => {
+    const map = new Map<number, PracticeStatus>();
+    practiceRows?.forEach((r) => {
+      if (r.song_id !== null) map.set(r.song_id, (r.status as PracticeStatus) ?? 'not_ready');
+    });
+    return map;
+  }, [practiceRows]);
+
+  const { notReady, passable, allSongs } = useMemo(() => {
+    const all = (songs ?? []).filter((s) => s.name);
+    const nr = all.filter((s) => (statusBySongId.get(s.id) ?? 'not_ready') === 'not_ready');
+    const pa = all.filter((s) => statusBySongId.get(s.id) === 'passable');
+    return { notReady: nr, passable: pa, allSongs: all };
+  }, [songs, statusBySongId]);
+
+  const pickSong = useCallback(
+    (exclude?: number) => {
+      if (allSongs.length === 0) return;
+      const pool = notReady.length > 0 ? notReady : passable.length > 0 ? passable : allSongs;
+      const excludeSong = exclude !== undefined ? pool.find((s) => s.id === exclude) : undefined;
+      const picked = pickRandom(pool, excludeSong);
+      setPickedSongId(picked.id);
+    },
+    [notReady, passable, allSongs]
+  );
+
+  useEffect(() => {
+    if (!songsLoading && !progressLoading && pickedSongId === null && allSongs.length > 0) {
+      pickSong();
+    }
+  }, [songsLoading, progressLoading, pickedSongId, allSongs.length, pickSong]);
+
+  const pickedSong = useMemo(
+    () => allSongs.find((s) => s.id === pickedSongId) ?? null,
+    [allSongs, pickedSongId]
+  );
+
+  const currentStatus: PracticeStatus = pickedSongId
+    ? (statusBySongId.get(pickedSongId) ?? 'not_ready')
+    : 'not_ready';
+
+  async function handleStatusChange(_: React.MouseEvent, newStatus: PracticeStatus | null) {
+    if (!newStatus || !pickedSongId) return;
+    setSaving(true);
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      setToast({ open: true, severity: 'error', message: 'Not logged in.' });
+      setSaving(false);
+      return;
+    }
+
+    const { error } = await supabase
+      .from('practice_progress')
+      .upsert(
+        {
+          song_id: pickedSongId,
+          user_id: user.id,
+          band_id: bandId,
+          status: newStatus,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'song_id,user_id' }
+      );
+
+    setSaving(false);
+
+    if (error) {
+      setToast({ open: true, severity: 'error', message: error.message });
+    } else {
+      mutate();
+      setToast({ open: true, severity: 'success', message: 'Status updated.' });
+    }
+  }
+
+  const isLoading = songsLoading || progressLoading;
+
+  if (!isLoading && allSongs.length === 0) return null;
+
+  return (
+    <>
+      <Paper variant="outlined" sx={{ p: 2.5, mb: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+          <MusicNoteIcon sx={{ fontSize: 18, color: 'primary.main' }} />
+          <Typography variant="subtitle1" fontWeight={600}>
+            Practice This Song
+          </Typography>
+        </Box>
+
+        {isLoading ? (
+          <Typography variant="body2" color="text.secondary">
+            Loading…
+          </Typography>
+        ) : pickedSong ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+              <Typography variant="h6" fontWeight={600} sx={{ lineHeight: 1.2 }}>
+                {pickedSong.name}
+              </Typography>
+              {pickedSong.artist && (
+                <Typography variant="body2" color="text.secondary">
+                  — {pickedSong.artist}
+                </Typography>
+              )}
+              <Chip
+                size="small"
+                label={STATUS_LABEL[currentStatus]}
+                color={STATUS_COLOR[currentStatus]}
+                sx={{ ml: 0.5 }}
+              />
+            </Box>
+
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+              <Typography variant="body2" color="text.secondary" sx={{ mr: 0.5 }}>
+                Update status:
+              </Typography>
+              <ToggleButtonGroup
+                value={currentStatus}
+                exclusive
+                size="small"
+                disabled={saving}
+                onChange={handleStatusChange}
+              >
+                <ToggleButton value="not_ready" color="error">
+                  Not Ready
+                </ToggleButton>
+                <ToggleButton value="passable" color="warning">
+                  Passable
+                </ToggleButton>
+                <ToggleButton value="ready" color="success">
+                  Ready
+                </ToggleButton>
+              </ToggleButtonGroup>
+
+              <Tooltip title="Pick a different song">
+                <IconButton
+                  size="small"
+                  onClick={() => pickSong(pickedSongId ?? undefined)}
+                  sx={{ ml: 'auto' }}
+                >
+                  <CasinoIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          </Box>
+        ) : null}
+      </Paper>
+
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={3000}
+        onClose={() => setToast((t) => ({ ...t, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={toast.severity} onClose={() => setToast((t) => ({ ...t, open: false }))}>
+          {toast.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/components/PracticePrompt.tsx
+++ b/components/PracticePrompt.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import usePracticeProgress from '@/hooks/usePracticeProgress';
-import useSongs, { SongsComposite } from '@/hooks/useSongs';
+import useSongs from '@/hooks/useSongs';
 import { createClient } from '@/utils/supabase/client';
 import CasinoIcon from '@mui/icons-material/Casino';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';

--- a/components/PracticePrompt.tsx
+++ b/components/PracticePrompt.tsx
@@ -3,7 +3,7 @@
 import usePracticeProgress from '@/hooks/usePracticeProgress';
 import useSongs from '@/hooks/useSongs';
 import { createClient } from '@/utils/supabase/client';
-import CasinoIcon from '@mui/icons-material/Casino';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
@@ -140,7 +140,7 @@ export default function PracticePrompt({ bandId }: PracticePromptProps) {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
           <MusicNoteIcon sx={{ fontSize: 18, color: 'primary.main' }} />
           <Typography variant="subtitle1" fontWeight={600}>
-            Practice This Song
+            Got a few minutes? Work on this song.
           </Typography>
         </Box>
 
@@ -150,12 +150,20 @@ export default function PracticePrompt({ bandId }: PracticePromptProps) {
           </Typography>
         ) : pickedSong ? (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
               <Typography variant="h6" fontWeight={600} sx={{ lineHeight: 1.2 }}>
                 {pickedSong.name}
               </Typography>
+              <Tooltip title="Pick a different song">
+                <IconButton
+                  size="small"
+                  onClick={() => pickSong(pickedSongId ?? undefined)}
+                >
+                  <RefreshIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
               {pickedSong.artist && (
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" color="text.secondary" sx={{ ml: 0.5 }}>
                   — {pickedSong.artist}
                 </Typography>
               )}
@@ -188,16 +196,6 @@ export default function PracticePrompt({ bandId }: PracticePromptProps) {
                   Ready
                 </ToggleButton>
               </ToggleButtonGroup>
-
-              <Tooltip title="Pick a different song">
-                <IconButton
-                  size="small"
-                  onClick={() => pickSong(pickedSongId ?? undefined)}
-                  sx={{ ml: 'auto' }}
-                >
-                  <CasinoIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
             </Box>
           </Box>
         ) : null}

--- a/components/PracticePrompt.tsx
+++ b/components/PracticePrompt.tsx
@@ -1,16 +1,16 @@
 'use client';
 
+import BlockHeader from '@/components/design/BlockHeader';
 import usePracticeProgress from '@/hooks/usePracticeProgress';
 import useSongs from '@/hooks/useSongs';
 import { createClient } from '@/utils/supabase/client';
-import RefreshIcon from '@mui/icons-material/Refresh';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Snackbar from '@mui/material/Snackbar';
-import Alert from '@mui/material/Alert';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
@@ -18,18 +18,6 @@ import Typography from '@mui/material/Typography';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 type PracticeStatus = 'not_ready' | 'passable' | 'ready';
-
-const STATUS_LABEL: Record<PracticeStatus, string> = {
-  not_ready: 'Not Ready',
-  passable: 'Passable',
-  ready: 'Ready',
-};
-
-const STATUS_COLOR: Record<PracticeStatus, 'error' | 'warning' | 'success'> = {
-  not_ready: 'error',
-  passable: 'warning',
-  ready: 'success',
-};
 
 function pickRandom<T>(arr: T[], exclude?: T): T {
   if (arr.length === 1) return arr[0];
@@ -134,15 +122,28 @@ export default function PracticePrompt({ bandId }: PracticePromptProps) {
 
   if (!isLoading && allSongs.length === 0) return null;
 
+  const refreshAction = (
+    <Tooltip title="Pick a different song">
+      <span>
+        <IconButton
+          size="small"
+          onClick={() => pickSong(pickedSongId ?? undefined)}
+          disabled={isLoading || allSongs.length <= 1}
+        >
+          <RefreshIcon fontSize="small" />
+        </IconButton>
+      </span>
+    </Tooltip>
+  );
+
   return (
     <>
       <Paper variant="outlined" sx={{ p: 2.5, flex: 1 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
-          <MusicNoteIcon sx={{ fontSize: 18, color: 'primary.main' }} />
-          <Typography variant="subtitle1" fontWeight={600}>
-            Got a few minutes? Work on this song.
-          </Typography>
-        </Box>
+        <BlockHeader
+          icon={<MusicNoteIcon color="primary" />}
+          title="Got a few minutes? Work on this song."
+          action={refreshAction}
+        />
 
         {isLoading ? (
           <Typography variant="body2" color="text.secondary">
@@ -150,29 +151,15 @@ export default function PracticePrompt({ bandId }: PracticePromptProps) {
           </Typography>
         ) : pickedSong ? (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
               <Typography variant="h6" fontWeight={600} sx={{ lineHeight: 1.2 }}>
                 {pickedSong.name}
               </Typography>
-              <Tooltip title="Pick a different song">
-                <IconButton
-                  size="small"
-                  onClick={() => pickSong(pickedSongId ?? undefined)}
-                >
-                  <RefreshIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
               {pickedSong.artist && (
-                <Typography variant="body2" color="text.secondary" sx={{ ml: 0.5 }}>
+                <Typography variant="body2" color="text.secondary">
                   — {pickedSong.artist}
                 </Typography>
               )}
-              <Chip
-                size="small"
-                label={STATUS_LABEL[currentStatus]}
-                color={STATUS_COLOR[currentStatus]}
-                sx={{ ml: 0.5 }}
-              />
             </Box>
 
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>

--- a/components/PracticePrompt.tsx
+++ b/components/PracticePrompt.tsx
@@ -136,7 +136,7 @@ export default function PracticePrompt({ bandId }: PracticePromptProps) {
 
   return (
     <>
-      <Paper variant="outlined" sx={{ p: 2.5, mb: 3 }}>
+      <Paper variant="outlined" sx={{ p: 2.5, flex: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
           <MusicNoteIcon sx={{ fontSize: 18, color: 'primary.main' }} />
           <Typography variant="subtitle1" fontWeight={600}>

--- a/components/design/BlockHeader.tsx
+++ b/components/design/BlockHeader.tsx
@@ -1,0 +1,26 @@
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+
+interface BlockHeaderProps {
+  icon: React.ReactNode;
+  title: string;
+  action?: React.ReactNode;
+}
+
+export default function BlockHeader({ icon, title, action }: BlockHeaderProps) {
+  return (
+    <>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        {icon}
+        <Typography variant="subtitle1" fontWeight={700} lineHeight={1} sx={{ flex: 1 }}>
+          {title}
+        </Typography>
+        {action}
+      </Box>
+      <Divider sx={{ mb: 2 }} />
+    </>
+  );
+}
+
+export type { BlockHeaderProps };


### PR DESCRIPTION
## Summary

- Adds a **Practice This Song** block at the top of the band overview page
- Picks a random song prioritized by status: **Not Ready** first, then **Passable**, then any song if all are ready
- Includes a shuffle button (dice icon) to pick a different song using the same priority rules
- Inline status toggle (Not Ready / Passable / Ready) to update the song's practice status directly from the block
- Block is hidden if the band has no songs

## Test plan

- [ ] Verify block appears at the top of the overview page above the events calendar
- [ ] Confirm song selection priority: Not Ready songs are picked first
- [ ] Confirm fallback to Passable songs when no Not Ready songs exist
- [ ] Confirm fallback to any random song when all songs are Ready
- [ ] Click the dice/shuffle button and verify a different song is selected (won't repeat same song if alternatives exist)
- [ ] Change status via the toggle buttons and verify it saves correctly and the status chip updates
- [ ] Verify the block is hidden for bands with no songs

🤖 Generated with [Claude Code](https://claude.com/claude-code)