### PR TITLE
Fix setlist builder white background in dark mode

### DIFF
--- a/components/setlistEditor/helpers.ts
+++ b/components/setlistEditor/helpers.ts
@@ -4,7 +4,9 @@ import { Tables } from '@/types/supabase';
 import { BandEvent, SetlistComposite } from '@/types/composites';
 
 export function getDragDropBackgroundColorClassName(snapshot: DroppableStateSnapshot): string {
-  return snapshot.isDraggingOver ? 'bg-slate-300' : 'bg-white';
+  return snapshot.isDraggingOver
+    ? 'bg-slate-300 dark:bg-slate-700'
+    : 'bg-white dark:bg-[#1a0b0d]';
 }
 
 export function getEventDisplayName(event: BandEvent): string {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'media',
   corePlugins: {
     preflight: false,
   },


### PR DESCRIPTION
## Summary
- Added `darkMode: 'media'` to `tailwind.config.js` so Tailwind's `dark:` variants activate based on `prefers-color-scheme`
- Updated `getDragDropBackgroundColorClassName` in `helpers.ts` to use `dark:bg-[#1a0b0d]` (matching the MUI Paper dark background) instead of the hardcoded `bg-white`
- Also updated the drag-over state from `bg-slate-300` to `bg-slate-300 dark:bg-slate-700`

## Test plan
- [ ] Open the setlist builder in dark mode — set and unused songs areas should now have a dark background matching the rest of the UI
- [ ] Drag a song over a set/unused area in dark mode — the highlighted drag-over color should be a dark slate instead of light gray
- [ ] Verify light mode is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)