### PR TITLE
Add print setlist dropdown with song list print view

### DIFF
--- a/app/band/[bandId]/setlists/page.tsx
+++ b/app/band/[bandId]/setlists/page.tsx
@@ -78,6 +78,15 @@ function SetlistActionsMenu({
         </MenuItem>
         <MenuItem
           onClick={() => {
+            window.open(`/print/setlist/${setlistId}/songs`, '_blank');
+            handleClose();
+          }}
+        >
+          <ListItemIcon><PrintIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Print Setlist</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
             window.open(`/print/setlist/${setlistId}/chord-charts`, '_blank');
             handleClose();
           }}

--- a/app/print/setlist/[setlistId]/songs/page.tsx
+++ b/app/print/setlist/[setlistId]/songs/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import Loading from '@/components/design/Loading';
+import { getSetlistDisplayName } from '@/components/setlistEditor/helpers';
+import useSetlistWithSongs from '@/hooks/useSetlistWithSongs';
+import { Tables } from '@/types/supabase';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import PrintIcon from '@mui/icons-material/Print';
+import { useMemo } from 'react';
+
+interface PrintSetlistPageProps {
+  params: { setlistId: number };
+}
+
+interface SetSongs {
+  setNumber: number;
+  songs: Tables<'songs'>[];
+}
+
+export default function PrintSetlistPage({ params }: Readonly<PrintSetlistPageProps>) {
+  const { setlistId } = params;
+  const { data: setlist, isLoading } = useSetlistWithSongs({ setlistId });
+
+  const sets = useMemo<SetSongs[]>(() => {
+    if (!setlist) return [];
+    const sorted = [...setlist.setlist_songs].sort((a, b) => {
+      if (a.set !== b.set) return (a.set ?? 0) - (b.set ?? 0);
+      return (a.set_weight ?? 0) - (b.set_weight ?? 0);
+    });
+    const setMap = new Map<number, Tables<'songs'>[]>();
+    sorted.forEach((ss) => {
+      const setNum = ss.set ?? 0;
+      if (!setMap.has(setNum)) setMap.set(setNum, []);
+      setMap.get(setNum)!.push(ss.songs);
+    });
+    return Array.from(setMap.entries()).map(([setNumber, songs]) => ({ setNumber, songs }));
+  }, [setlist]);
+
+  if (isLoading) return <Loading />;
+  if (!setlist) return <Typography variant="h5">Setlist not found.</Typography>;
+
+  return (
+    <>
+      <style>{`
+        header, footer { display: none !important; }
+        main { padding-top: 0 !important; }
+        @media print {
+          .no-print { display: none !important; }
+          header, footer { display: none !important; }
+        }
+        @media print {
+          .sets-grid {
+            columns: 2;
+            column-gap: 2rem;
+          }
+          .set-block {
+            break-inside: avoid;
+          }
+        }
+      `}</style>
+
+      <Box className="no-print" sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Typography variant="h5" fontWeight={700}>
+          {getSetlistDisplayName(setlist)} — Setlist
+        </Typography>
+        <Button variant="contained" startIcon={<PrintIcon />} onClick={() => window.print()}>
+          Print
+        </Button>
+      </Box>
+
+      {sets.length === 0 ? (
+        <Typography color="text.secondary">No songs in this setlist.</Typography>
+      ) : (
+        <Box
+          className="sets-grid"
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: sets.length > 1 ? { xs: '1fr', sm: 'repeat(2, 1fr)' } : '1fr',
+            gap: 3,
+          }}
+        >
+          {sets.map(({ setNumber, songs }) => (
+            <Box key={setNumber} className="set-block">
+              <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 0.5, borderBottom: '1px solid', borderColor: 'divider', pb: 0.5 }}>
+                Set {setNumber + 1}
+              </Typography>
+              {songs.map((song, i) => (
+                <Box key={song.id} sx={{ py: 0.25 }}>
+                  <Typography variant="body2" fontWeight={500} component="div">
+                    {i + 1}. {song.name}
+                  </Typography>
+                  {song.artist && (
+                    <Typography variant="caption" color="text.secondary" component="div" sx={{ pl: 1.5 }}>
+                      {song.artist}
+                    </Typography>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          ))}
+        </Box>
+      )}
+    </>
+  );
+}

--- a/components/PrintDropdownButton.tsx
+++ b/components/PrintDropdownButton.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import PrintIcon from '@mui/icons-material/Print';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
+import Grow from '@mui/material/Grow';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MenuList from '@mui/material/MenuList';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Popper from '@mui/material/Popper';
+import { useRef, useState } from 'react';
+
+interface PrintOption {
+  label: string;
+  url: string;
+}
+
+interface PrintDropdownButtonProps {
+  options: PrintOption[];
+}
+
+export default function PrintDropdownButton({ options }: Readonly<PrintDropdownButtonProps>) {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <>
+      <ButtonGroup variant="outlined" ref={anchorRef}>
+        <Button startIcon={<PrintIcon />} onClick={() => setOpen((prev) => !prev)}>
+          Print
+        </Button>
+        <Button size="small" sx={{ px: 0.5 }} onClick={() => setOpen((prev) => !prev)}>
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+      <Popper open={open} anchorEl={anchorRef.current} placement="bottom-end" transition disablePortal style={{ zIndex: 1300 }}>
+        {({ TransitionProps }) => (
+          <Grow {...TransitionProps}>
+            <Paper elevation={3}>
+              <ClickAwayListener onClickAway={() => setOpen(false)}>
+                <MenuList dense>
+                  {options.map((option) => (
+                    <MenuItem
+                      key={option.label}
+                      onClick={() => {
+                        window.open(option.url, '_blank');
+                        setOpen(false);
+                      }}
+                    >
+                      <ListItemIcon>
+                        <PrintIcon fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>{option.label}</ListItemText>
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </>
+  );
+}

--- a/components/setlistEditor/SetlistEditor.tsx
+++ b/components/setlistEditor/SetlistEditor.tsx
@@ -15,7 +15,7 @@ import Paper from '@mui/material/Paper';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import PrintIcon from '@mui/icons-material/Print';
+import PrintDropdownButton from '@/components/PrintDropdownButton';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
@@ -238,13 +238,12 @@ export default function SetlistEditor({
               </Button>
               <Box sx={{ display: 'flex', gap: 1 }}>
                 {setlist.id && (
-                  <Button
-                    variant="outlined"
-                    startIcon={<PrintIcon />}
-                    onClick={() => window.open(`/print/setlist/${setlist.id}/chord-charts`, '_blank')}
-                  >
-                    Print Chord Charts
-                  </Button>
+                  <PrintDropdownButton
+                    options={[
+                      { label: 'Print Setlist', url: `/print/setlist/${setlist.id}/songs` },
+                      { label: 'Print Chord Charts', url: `/print/setlist/${setlist.id}/chord-charts` },
+                    ]}
+                  />
                 )}
                 <Button variant="contained" onClick={saveSetlist}>
                   Save Setlist

--- a/components/setlistEditor/SetlistEditor.tsx
+++ b/components/setlistEditor/SetlistEditor.tsx
@@ -200,7 +200,7 @@ export default function SetlistEditor({
 
   return (
     <>
-      <Box className="flex gap-4 pb-3" sx={{ flexWrap: 'wrap' }}>
+      <Box className="flex gap-4 pb-3" sx={{ flexWrap: 'wrap', alignItems: 'center' }}>
         <FormControl variant="outlined" size="small" sx={{ width: 300 }}>
           <InputLabel id="event-select-label">Event</InputLabel>
           <Select
@@ -227,6 +227,14 @@ export default function SetlistEditor({
           placeholder={selectedEvent ? 'Override event name…' : 'My Setlist'}
           sx={{ width: 300 }}
         />
+        {setlist.id && (
+          <PrintDropdownButton
+            options={[
+              { label: 'Print Setlist', url: `/print/setlist/${setlist.id}/songs` },
+              { label: 'Print Chord Charts', url: `/print/setlist/${setlist.id}/chord-charts` },
+            ]}
+          />
+        )}
       </Box>
       <DragDropContext onDragEnd={onDragEnd}>
         <Grid container spacing={2}>
@@ -236,19 +244,9 @@ export default function SetlistEditor({
               <Button variant="contained" onClick={addSetlist}>
                 Add Set
               </Button>
-              <Box sx={{ display: 'flex', gap: 1 }}>
-                {setlist.id && (
-                  <PrintDropdownButton
-                    options={[
-                      { label: 'Print Setlist', url: `/print/setlist/${setlist.id}/songs` },
-                      { label: 'Print Chord Charts', url: `/print/setlist/${setlist.id}/chord-charts` },
-                    ]}
-                  />
-                )}
-                <Button variant="contained" onClick={saveSetlist}>
-                  Save Setlist
-                </Button>
-              </Box>
+              <Button variant="contained" onClick={saveSetlist}>
+                Save Setlist
+              </Button>
             </Box>
           </Grid>
           <Grid item xs={12} sm={6}>


### PR DESCRIPTION
Replaces the standalone "Print Chord Charts" button in the setlist editor with a split-button dropdown (Print ▾) that exposes both "Print Setlist" and "Print Chord Charts" options. Adds a new /print/setlist/[setlistId]/songs page that lists each set with song titles and artists, laid out in a two-column grid for multi-set setlists to help content fit on one page. Also adds "Print Setlist" to the actions menu on the setlists list page.

https://claude.ai/code/session_01K8hjqke65fbjb2zykxX6XM