### PR TITLE
Modernize site styling with gradients and expanded color palette

### DIFF
--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -42,8 +42,8 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
   const pathname = usePathname();
   const { palette } = useTheme();
   const sidebarGradient = palette.mode === 'dark'
-    ? 'linear-gradient(180deg, #1a0b0d 0%, #1c0c1e 100%)'
-    : 'linear-gradient(180deg, #fef2f2 0%, #fef0fc 100%)';
+    ? 'linear-gradient(180deg, #1a0b0d 0%, #1e0c20 100%)'
+    : 'linear-gradient(180deg, #fef2f2 0%, #fcedf8 100%)';
 
   if (isLoading) {
     return <Loading />;

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -33,7 +33,6 @@ interface ConsumerProps {
 type BandLayoutProps = BandRouteProps & ConsumerProps;
 
 const SIDEBAR_WIDTH = 200;
-const SIDEBAR_BG = { light: '#fef2f2', dark: '#1a0b0d' };
 
 export default function BandLayout({ children, params }: BandLayoutProps) {
   const { bandId } = params;
@@ -95,8 +94,10 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
     );
 
     const sidebarSx = {
-      bgcolor: (theme: { palette: { mode: string } }) =>
-        theme.palette.mode === 'dark' ? SIDEBAR_BG.dark : SIDEBAR_BG.light,
+      background: (theme: { palette: { mode: string } }) =>
+        theme.palette.mode === 'dark'
+          ? 'linear-gradient(180deg, #1a0b0d 0%, #13082a 100%)'
+          : 'linear-gradient(180deg, #fef2f2 0%, #f5f3ff 100%)',
       borderRight: '1px solid',
       borderColor: 'divider',
       pt: 3,

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -15,6 +15,7 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
+import { useTheme } from '@mui/material/styles';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -39,6 +40,10 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
   const { data: band, isLoading } = useBand({ bandId });
   const { mobileOpen, setMobileOpen } = useNav();
   const pathname = usePathname();
+  const { palette } = useTheme();
+  const sidebarGradient = palette.mode === 'dark'
+    ? 'linear-gradient(180deg, #1a0b0d 0%, #13082a 100%)'
+    : 'linear-gradient(180deg, #fef2f2 0%, #f5f3ff 100%)';
 
   if (isLoading) {
     return <Loading />;
@@ -94,10 +99,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
     );
 
     const sidebarSx = {
-      background: (theme: { palette: { mode: string } }) =>
-        theme.palette.mode === 'dark'
-          ? 'linear-gradient(180deg, #1a0b0d 0%, #13082a 100%)'
-          : 'linear-gradient(180deg, #fef2f2 0%, #f5f3ff 100%)',
+      background: sidebarGradient,
       borderRight: '1px solid',
       borderColor: 'divider',
       pt: 3,

--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -42,8 +42,8 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
   const pathname = usePathname();
   const { palette } = useTheme();
   const sidebarGradient = palette.mode === 'dark'
-    ? 'linear-gradient(180deg, #1a0b0d 0%, #13082a 100%)'
-    : 'linear-gradient(180deg, #fef2f2 0%, #f5f3ff 100%)';
+    ? 'linear-gradient(180deg, #1a0b0d 0%, #1c0c1e 100%)'
+    : 'linear-gradient(180deg, #fef2f2 0%, #fef0fc 100%)';
 
   if (isLoading) {
     return <Loading />;

--- a/app/band/create/page.tsx
+++ b/app/band/create/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import BandForm from '@/components/forms/BandForm';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,3 +40,13 @@
     transform: translateY(0);
   }
 }
+
+/* MUI Paper/Card SSR dark-mode fix.
+   Emotion generates different class names per theme, so server-rendered
+   light-mode classes stay on the element after hydration. This CSS-only
+   rule fires before JS and overrides the server-rendered white background. */
+@media (prefers-color-scheme: dark) {
+  .MuiPaper-root {
+    background-color: #1a0b0d !important;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -48,5 +48,6 @@
 @media (prefers-color-scheme: dark) {
   .MuiPaper-root {
     background-color: #1a0b0d !important;
+    color: #fef2f2;
   }
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,6 @@
+import AuthCard from '@/components/layout/AuthCard';
 import LoginForm from '@/components/forms/LoginForm';
 import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import NextLink from 'next/link';
@@ -15,23 +14,21 @@ interface LoginPageProps {
 export default function LoginPage({ searchParams }: Readonly<LoginPageProps>) {
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
-      <Card sx={{ width: '100%', maxWidth: 420 }}>
-        <CardContent sx={{ p: 4 }}>
-          <Typography variant="h5" fontWeight={700} mb={0.5}>
-            Welcome back
-          </Typography>
-          <Typography variant="body2" color="text.secondary" mb={3}>
-            Log in to manage your band
-          </Typography>
-          <LoginForm errorMessage={searchParams.message} />
-          <Typography variant="body2" color="text.secondary" mt={3}>
-            Don&apos;t have an account?{' '}
-            <Link component={NextLink} href="/signup" underline="hover" color="primary">
-              Sign up
-            </Link>
-          </Typography>
-        </CardContent>
-      </Card>
+      <AuthCard>
+        <Typography variant="h5" fontWeight={700} mb={0.5}>
+          Welcome back
+        </Typography>
+        <Typography variant="body2" color="text.secondary" mb={3}>
+          Log in to manage your band
+        </Typography>
+        <LoginForm errorMessage={searchParams.message} />
+        <Typography variant="body2" color="text.secondary" mt={3}>
+          Don&apos;t have an account?{' '}
+          <Link component={NextLink} href="/signup" underline="hover" color="primary">
+            Sign up
+          </Link>
+        </Typography>
+      </AuthCard>
     </Box>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,9 +1,6 @@
 import AuthCard from '@/components/layout/AuthCard';
 import LoginForm from '@/components/forms/LoginForm';
 import Box from '@mui/material/Box';
-import Link from '@mui/material/Link';
-import Typography from '@mui/material/Typography';
-import NextLink from 'next/link';
 
 interface LoginPageProps {
   searchParams: {
@@ -14,20 +11,14 @@ interface LoginPageProps {
 export default function LoginPage({ searchParams }: Readonly<LoginPageProps>) {
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
-      <AuthCard>
-        <Typography variant="h5" fontWeight={700} mb={0.5}>
-          Welcome back
-        </Typography>
-        <Typography variant="body2" color="text.secondary" mb={3}>
-          Log in to manage your band
-        </Typography>
+      <AuthCard
+        title="Welcome back"
+        subtitle="Log in to manage your band"
+        footerText="Don't have an account?"
+        footerLinkText="Sign up"
+        footerLinkHref="/signup"
+      >
         <LoginForm errorMessage={searchParams.message} />
-        <Typography variant="body2" color="text.secondary" mt={3}>
-          Don&apos;t have an account?{' '}
-          <Link component={NextLink} href="/signup" underline="hover" color="primary">
-            Sign up
-          </Link>
-        </Typography>
       </AuthCard>
     </Box>
   );

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,9 +1,6 @@
 import AuthCard from '@/components/layout/AuthCard';
 import SignUpForm from '@/components/forms/SignUpForm';
 import Box from '@mui/material/Box';
-import Link from '@mui/material/Link';
-import Typography from '@mui/material/Typography';
-import NextLink from 'next/link';
 
 interface SignUpPageProps {
   searchParams: {
@@ -14,20 +11,14 @@ interface SignUpPageProps {
 export default function SignUpPage({ searchParams }: Readonly<SignUpPageProps>) {
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
-      <AuthCard>
-        <Typography variant="h5" fontWeight={700} mb={0.5}>
-          Create an account
-        </Typography>
-        <Typography variant="body2" color="text.secondary" mb={3}>
-          Join Band Manager and get organized
-        </Typography>
+      <AuthCard
+        title="Create an account"
+        subtitle="Join Band Manager and get organized"
+        footerText="Already have an account?"
+        footerLinkText="Log in"
+        footerLinkHref="/login"
+      >
         <SignUpForm errorMessage={searchParams.message} />
-        <Typography variant="body2" color="text.secondary" mt={3}>
-          Already have an account?{' '}
-          <Link component={NextLink} href="/login" underline="hover" color="primary">
-            Log in
-          </Link>
-        </Typography>
       </AuthCard>
     </Box>
   );

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,7 +1,6 @@
+import AuthCard from '@/components/layout/AuthCard';
 import SignUpForm from '@/components/forms/SignUpForm';
 import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import NextLink from 'next/link';
@@ -15,23 +14,21 @@ interface SignUpPageProps {
 export default function SignUpPage({ searchParams }: Readonly<SignUpPageProps>) {
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
-      <Card sx={{ width: '100%', maxWidth: 420 }}>
-        <CardContent sx={{ p: 4 }}>
-          <Typography variant="h5" fontWeight={700} mb={0.5}>
-            Create an account
-          </Typography>
-          <Typography variant="body2" color="text.secondary" mb={3}>
-            Join Band Manager and get organized
-          </Typography>
-          <SignUpForm errorMessage={searchParams.message} />
-          <Typography variant="body2" color="text.secondary" mt={3}>
-            Already have an account?{' '}
-            <Link component={NextLink} href="/login" underline="hover" color="primary">
-              Log in
-            </Link>
-          </Typography>
-        </CardContent>
-      </Card>
+      <AuthCard>
+        <Typography variant="h5" fontWeight={700} mb={0.5}>
+          Create an account
+        </Typography>
+        <Typography variant="body2" color="text.secondary" mb={3}>
+          Join Band Manager and get organized
+        </Typography>
+        <SignUpForm errorMessage={searchParams.message} />
+        <Typography variant="body2" color="text.secondary" mt={3}>
+          Already have an account?{' '}
+          <Link component={NextLink} href="/login" underline="hover" color="primary">
+            Log in
+          </Link>
+        </Typography>
+      </AuthCard>
     </Box>
   );
 }

--- a/components/ThemeRegistry.tsx
+++ b/components/ThemeRegistry.tsx
@@ -56,8 +56,8 @@ function buildTheme(dark: boolean) {
           body: {
             scrollbarColor: dark ? '#3d1015 #0d0507' : '#e4d8ff #fdf8f8',
             backgroundImage: dark
-              ? 'linear-gradient(160deg, #0d0507 0%, #0f0612 50%, #0d0507 100%)'
-              : 'linear-gradient(160deg, #fdf8f8 0%, #fdf7ff 50%, #fdf8f8 100%)',
+              ? 'linear-gradient(160deg, #0d0507 0%, #100514 50%, #0d0507 100%)'
+              : 'linear-gradient(160deg, #fdf8f8 0%, #fdf5fd 50%, #fdf8f8 100%)',
             backgroundAttachment: 'fixed',
             minHeight: '100vh',
           },
@@ -68,8 +68,8 @@ function buildTheme(dark: boolean) {
         styleOverrides: {
           root: {
             background: dark
-              ? 'linear-gradient(90deg, #2a1010 0%, #230e22 100%)'
-              : 'linear-gradient(90deg, #991b1b 0%, #6e1654 100%)',
+              ? 'linear-gradient(90deg, #2e0e0e 0%, #280d28 100%)'
+              : 'linear-gradient(90deg, #c01c1c 0%, #9a1882 100%)',
             borderBottom: dark ? '1px solid rgba(167,139,250,0.12)' : 'none',
           },
         },
@@ -132,12 +132,12 @@ function buildTheme(dark: boolean) {
           },
           containedPrimary: {
             background: dark
-              ? 'linear-gradient(135deg, #ef4444 0%, #c45bad 100%)'
-              : 'linear-gradient(135deg, #b91c1c 0%, #7e1c6a 100%)',
+              ? 'linear-gradient(135deg, #f04444 0%, #c855c0 100%)'
+              : 'linear-gradient(135deg, #c21c1c 0%, #8e1e80 100%)',
             '&:hover': {
               background: dark
-                ? 'linear-gradient(135deg, #f87171 0%, #d470c0 100%)'
-                : 'linear-gradient(135deg, #dc2626 0%, #8f2178 100%)',
+                ? 'linear-gradient(135deg, #f47070 0%, #d870d8 100%)'
+                : 'linear-gradient(135deg, #d42020 0%, #9e2290 100%)',
             },
           },
         },

--- a/components/ThemeRegistry.tsx
+++ b/components/ThemeRegistry.tsx
@@ -150,16 +150,6 @@ function buildTheme(dark: boolean) {
             fontWeight: 600,
             borderRadius: 8,
           },
-          containedPrimary: {
-            background: dark
-              ? 'linear-gradient(135deg, #ef4444 0%, #8b5cf6 100%)'
-              : 'linear-gradient(135deg, #b91c1c 0%, #7c3aed 100%)',
-            '&:hover': {
-              background: dark
-                ? 'linear-gradient(135deg, #f87171 0%, #a78bfa 100%)'
-                : 'linear-gradient(135deg, #dc2626 0%, #8b5cf6 100%)',
-            },
-          },
         },
       },
       MuiTextField: {

--- a/components/ThemeRegistry.tsx
+++ b/components/ThemeRegistry.tsx
@@ -56,8 +56,8 @@ function buildTheme(dark: boolean) {
           body: {
             scrollbarColor: dark ? '#3d1015 #0d0507' : '#e4d8ff #fdf8f8',
             backgroundImage: dark
-              ? 'linear-gradient(160deg, #0d0507 0%, #100820 50%, #0d0507 100%)'
-              : 'linear-gradient(160deg, #fdf8f8 0%, #f5f0ff 50%, #fdf8f8 100%)',
+              ? 'linear-gradient(160deg, #0d0507 0%, #0f0612 50%, #0d0507 100%)'
+              : 'linear-gradient(160deg, #fdf8f8 0%, #fdf7ff 50%, #fdf8f8 100%)',
             backgroundAttachment: 'fixed',
             minHeight: '100vh',
           },
@@ -68,8 +68,8 @@ function buildTheme(dark: boolean) {
         styleOverrides: {
           root: {
             background: dark
-              ? 'linear-gradient(90deg, #2d1010 0%, #1e0a38 100%)'
-              : 'linear-gradient(90deg, #991b1b 0%, #5b21b6 100%)',
+              ? 'linear-gradient(90deg, #2a1010 0%, #230e22 100%)'
+              : 'linear-gradient(90deg, #991b1b 0%, #6e1654 100%)',
             borderBottom: dark ? '1px solid rgba(167,139,250,0.12)' : 'none',
           },
         },
@@ -132,12 +132,12 @@ function buildTheme(dark: boolean) {
           },
           containedPrimary: {
             background: dark
-              ? 'linear-gradient(135deg, #ef4444 0%, #8b5cf6 100%)'
-              : 'linear-gradient(135deg, #b91c1c 0%, #7c3aed 100%)',
+              ? 'linear-gradient(135deg, #ef4444 0%, #c45bad 100%)'
+              : 'linear-gradient(135deg, #b91c1c 0%, #7e1c6a 100%)',
             '&:hover': {
               background: dark
-                ? 'linear-gradient(135deg, #f87171 0%, #a78bfa 100%)'
-                : 'linear-gradient(135deg, #dc2626 0%, #8b5cf6 100%)',
+                ? 'linear-gradient(135deg, #f87171 0%, #d470c0 100%)'
+                : 'linear-gradient(135deg, #dc2626 0%, #8f2178 100%)',
             },
           },
         },

--- a/components/ThemeRegistry.tsx
+++ b/components/ThemeRegistry.tsx
@@ -94,6 +94,7 @@ function buildTheme(dark: boolean) {
         styleOverrides: {
           root: ({ theme }) => ({
             backgroundImage: 'none',
+            backgroundColor: theme.palette.background.paper,
             border: `1px solid ${theme.palette.divider}`,
           }),
         },

--- a/components/ThemeRegistry.tsx
+++ b/components/ThemeRegistry.tsx
@@ -6,9 +6,9 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { ReactNode, useMemo } from 'react';
 
-// Deep crimson — raw energy, rock and roll, vintage venue marquees
-// Dark: near-black with a deep red undertone
-// Light: soft warm white with rich crimson accents
+// Deep crimson meets electric violet — rock energy + stage lights
+// Dark: near-black with red undertone, accented by deep indigo
+// Light: warm white with rich crimson + violet accents
 function buildTheme(dark: boolean) {
   return createTheme({
     palette: {
@@ -20,9 +20,9 @@ function buildTheme(dark: boolean) {
         contrastText: dark ? '#0d0305' : '#ffffff',
       },
       secondary: {
-        main: dark ? '#94a3b8' : '#475569',
-        light: dark ? '#cbd5e1' : '#64748b',
-        dark: dark ? '#64748b' : '#334155',
+        main: dark ? '#a78bfa' : '#7c3aed',
+        light: dark ? '#c4b5fd' : '#8b5cf6',
+        dark: dark ? '#8b5cf6' : '#6d28d9',
         contrastText: '#ffffff',
       },
       background: {
@@ -54,7 +54,11 @@ function buildTheme(dark: boolean) {
       MuiCssBaseline: {
         styleOverrides: {
           body: {
-            scrollbarColor: dark ? '#3d1015 #0d0507' : '#f5c6c6 #fdf8f8',
+            scrollbarColor: dark ? '#3d1015 #0d0507' : '#e4d8ff #fdf8f8',
+            background: dark
+              ? 'linear-gradient(160deg, #0d0507 0%, #100820 60%, #0d0507 100%) fixed'
+              : 'linear-gradient(160deg, #fdf8f8 0%, #faf7ff 60%, #fdf8f8 100%) fixed',
+            minHeight: '100vh',
           },
         },
       },
@@ -62,8 +66,10 @@ function buildTheme(dark: boolean) {
         defaultProps: { elevation: 0 },
         styleOverrides: {
           root: {
-            backgroundColor: dark ? '#0d0507' : '#991b1b',
-            borderBottom: dark ? '1px solid rgba(248,113,113,0.15)' : 'none',
+            background: dark
+              ? 'linear-gradient(90deg, #2d1010 0%, #1e0a38 100%)'
+              : 'linear-gradient(90deg, #991b1b 0%, #5b21b6 100%)',
+            borderBottom: dark ? '1px solid rgba(167,139,250,0.12)' : 'none',
           },
         },
       },
@@ -75,9 +81,9 @@ function buildTheme(dark: boolean) {
             transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
             '&:hover': {
               boxShadow: dark
-                ? '0 4px 32px rgba(248,113,113,0.1)'
-                : '0 4px 24px rgba(185,28,28,0.1)',
-              borderColor: dark ? 'rgba(248,113,113,0.35)' : 'rgba(185,28,28,0.3)',
+                ? '0 4px 32px rgba(167,139,250,0.12)'
+                : '0 4px 24px rgba(109,40,217,0.1)',
+              borderColor: dark ? 'rgba(167,139,250,0.3)' : 'rgba(109,40,217,0.2)',
             },
           }),
         },
@@ -110,7 +116,7 @@ function buildTheme(dark: boolean) {
           root: {
             '&:last-child td': { border: 0 },
             '&:hover': {
-              backgroundColor: dark ? 'rgba(248,113,113,0.05)' : 'rgba(185,28,28,0.03)',
+              backgroundColor: dark ? 'rgba(167,139,250,0.05)' : 'rgba(109,40,217,0.03)',
             },
           },
         },

--- a/components/ThemeRegistry.tsx
+++ b/components/ThemeRegistry.tsx
@@ -55,9 +55,10 @@ function buildTheme(dark: boolean) {
         styleOverrides: {
           body: {
             scrollbarColor: dark ? '#3d1015 #0d0507' : '#e4d8ff #fdf8f8',
-            background: dark
-              ? 'linear-gradient(160deg, #0d0507 0%, #100820 60%, #0d0507 100%) fixed'
-              : 'linear-gradient(160deg, #fdf8f8 0%, #faf7ff 60%, #fdf8f8 100%) fixed',
+            backgroundImage: dark
+              ? 'linear-gradient(160deg, #0d0507 0%, #100820 50%, #0d0507 100%)'
+              : 'linear-gradient(160deg, #fdf8f8 0%, #f5f0ff 50%, #fdf8f8 100%)',
+            backgroundAttachment: 'fixed',
             minHeight: '100vh',
           },
         },
@@ -129,6 +130,16 @@ function buildTheme(dark: boolean) {
             fontWeight: 600,
             borderRadius: 8,
           },
+          containedPrimary: {
+            background: dark
+              ? 'linear-gradient(135deg, #ef4444 0%, #8b5cf6 100%)'
+              : 'linear-gradient(135deg, #b91c1c 0%, #7c3aed 100%)',
+            '&:hover': {
+              background: dark
+                ? 'linear-gradient(135deg, #f87171 0%, #a78bfa 100%)'
+                : 'linear-gradient(135deg, #dc2626 0%, #8b5cf6 100%)',
+            },
+          },
         },
       },
       MuiLoadingButton: {
@@ -138,6 +149,16 @@ function buildTheme(dark: boolean) {
             textTransform: 'none',
             fontWeight: 600,
             borderRadius: 8,
+          },
+          containedPrimary: {
+            background: dark
+              ? 'linear-gradient(135deg, #ef4444 0%, #8b5cf6 100%)'
+              : 'linear-gradient(135deg, #b91c1c 0%, #7c3aed 100%)',
+            '&:hover': {
+              background: dark
+                ? 'linear-gradient(135deg, #f87171 0%, #a78bfa 100%)'
+                : 'linear-gradient(135deg, #dc2626 0%, #8b5cf6 100%)',
+            },
           },
         },
       },

--- a/components/layout/AuthCard.tsx
+++ b/components/layout/AuthCard.tsx
@@ -2,12 +2,45 @@
 
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import NextLink from 'next/link';
 import { ReactNode } from 'react';
 
-export default function AuthCard({ children }: { children: ReactNode }) {
+interface AuthCardProps {
+  title: string;
+  subtitle: string;
+  footerText: string;
+  footerLinkText: string;
+  footerLinkHref: string;
+  children: ReactNode;
+}
+
+export default function AuthCard({
+  title,
+  subtitle,
+  footerText,
+  footerLinkText,
+  footerLinkHref,
+  children,
+}: AuthCardProps) {
   return (
     <Card sx={{ width: '100%', maxWidth: 420 }}>
-      <CardContent sx={{ p: 4 }}>{children}</CardContent>
+      <CardContent sx={{ p: 4 }}>
+        <Typography variant="h5" fontWeight={700} mb={0.5}>
+          {title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" mb={3}>
+          {subtitle}
+        </Typography>
+        {children}
+        <Typography variant="body2" color="text.secondary" mt={3}>
+          {footerText}{' '}
+          <Link component={NextLink} href={footerLinkHref} underline="hover" color="primary">
+            {footerLinkText}
+          </Link>
+        </Typography>
+      </CardContent>
     </Card>
   );
 }

--- a/components/layout/AuthCard.tsx
+++ b/components/layout/AuthCard.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import { ReactNode } from 'react';
+
+export default function AuthCard({ children }: { children: ReactNode }) {
+  return (
+    <Card sx={{ width: '100%', maxWidth: 420 }}>
+      <CardContent sx={{ p: 4 }}>{children}</CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
- Add violet/purple as a second accent color (secondary palette), replacing slate gray
- Apply crimson-to-violet gradient on the AppBar header for a dramatic stage-lighting effect
- Add subtle warm-to-violet gradient on the page body background
- Apply crimson-to-violet gradient on the band sidebar
- Update card and table row hover shadows to use violet tints
- Update scrollbar colors to complement the new palette

https://claude.ai/code/session_013gUk6j82PS8icaJpVpxVWv