### PR TITLE
Add chord chart view button to practice table and practice block

### DIFF
--- a/app/band/[bandId]/practice/page.tsx
+++ b/app/band/[bandId]/practice/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Loading from '@/components/design/Loading';
+import ChordChartViewModal from '@/components/modals/ChordChartViewModal';
 import usePracticeProgress from '@/hooks/usePracticeProgress';
 import useSetlists from '@/hooks/useSetlists';
 import useSongs from '@/hooks/useSongs';
@@ -386,6 +387,11 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
                     <Typography variant="body2" color="text.secondary">
                       {song.artist}
                     </Typography>
+                  )}
+                  {song.chord_chart && (
+                    <Box sx={{ mt: 0.5 }}>
+                      <ChordChartViewModal songName={song.name} chordChart={song.chord_chart} />
+                    </Box>
                   )}
                 </TableCell>
                 <TableCell sx={{ whiteSpace: 'nowrap' }}>

--- a/app/band/[bandId]/practice/page.tsx
+++ b/app/band/[bandId]/practice/page.tsx
@@ -358,6 +358,7 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
                   </TableSortLabel>
                 )}
               </TableCell>
+              <TableCell>Chord Chart</TableCell>
               <TableCell>
                 {setlistFilter ? (
                   'Notes'
@@ -388,10 +389,10 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
                       {song.artist}
                     </Typography>
                   )}
+                </TableCell>
+                <TableCell>
                   {song.chord_chart && (
-                    <Box sx={{ mt: 0.5 }}>
-                      <ChordChartViewModal songName={song.name} chordChart={song.chord_chart} />
-                    </Box>
+                    <ChordChartViewModal songName={song.name} chordChart={song.chord_chart} />
                   )}
                 </TableCell>
                 <TableCell sx={{ whiteSpace: 'nowrap' }}>

--- a/app/band/[bandId]/practice/page.tsx
+++ b/app/band/[bandId]/practice/page.tsx
@@ -358,8 +358,7 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
                   </TableSortLabel>
                 )}
               </TableCell>
-              <TableCell>Chord Chart</TableCell>
-              <TableCell>
+              <TableCell>View Chords</TableCell>              <TableCell>
                 {setlistFilter ? (
                   'Notes'
                 ) : (
@@ -390,11 +389,6 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
                     </Typography>
                   )}
                 </TableCell>
-                <TableCell>
-                  {song.chord_chart && (
-                    <ChordChartViewModal songName={song.name} chordChart={song.chord_chart} />
-                  )}
-                </TableCell>
                 <TableCell sx={{ whiteSpace: 'nowrap' }}>
                   <ToggleButtonGroup
                     value={p.status}
@@ -414,6 +408,11 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
                       Ready
                     </ToggleButton>
                   </ToggleButtonGroup>
+                </TableCell>
+                <TableCell>
+                  {song.chord_chart && (
+                    <ChordChartViewModal songName={song.name} chordChart={song.chord_chart} />
+                  )}
                 </TableCell>
                 <TableCell sx={{ minWidth: 260 }}>
                   <TextField

--- a/components/PracticePrompt.tsx
+++ b/components/PracticePrompt.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import BlockHeader from '@/components/design/BlockHeader';
+import ChordChartViewModal from '@/components/modals/ChordChartViewModal';
 import usePracticeProgress from '@/hooks/usePracticeProgress';
 import useSongs from '@/hooks/useSongs';
 import { createClient } from '@/utils/supabase/client';
@@ -161,6 +162,10 @@ export default function PracticePrompt({ bandId }: PracticePromptProps) {
                 </Typography>
               )}
             </Box>
+
+            {pickedSong.chord_chart && (
+              <ChordChartViewModal songName={pickedSong.name} chordChart={pickedSong.chord_chart} />
+            )}
 
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
               <Typography variant="body2" color="text.secondary" sx={{ mr: 0.5 }}>

--- a/components/PracticePrompt.tsx
+++ b/components/PracticePrompt.tsx
@@ -152,20 +152,21 @@ export default function PracticePrompt({ bandId }: PracticePromptProps) {
           </Typography>
         ) : pickedSong ? (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-              <Typography variant="h6" fontWeight={600} sx={{ lineHeight: 1.2 }}>
-                {pickedSong.name}
-              </Typography>
-              {pickedSong.artist && (
-                <Typography variant="body2" color="text.secondary">
-                  — {pickedSong.artist}
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+              <Box>
+                <Typography variant="h6" fontWeight={600} sx={{ lineHeight: 1.2 }}>
+                  {pickedSong.name}
                 </Typography>
+                {pickedSong.artist && (
+                  <Typography variant="body2" color="text.secondary">
+                    {pickedSong.artist}
+                  </Typography>
+                )}
+              </Box>
+              {pickedSong.chord_chart && (
+                <ChordChartViewModal songName={pickedSong.name} chordChart={pickedSong.chord_chart} />
               )}
             </Box>
-
-            {pickedSong.chord_chart && (
-              <ChordChartViewModal songName={pickedSong.name} chordChart={pickedSong.chord_chart} />
-            )}
 
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
               <Typography variant="body2" color="text.secondary" sx={{ mr: 0.5 }}>


### PR DESCRIPTION
Shows a 'View Chords' button in the song cell of the practice table and
below the song name in the practice block on the overview page, but only
when the song has a chord chart stored.

https://claude.ai/code/session_0144k8ARQdfg3DcLEjcrdWhH