### PR TITLE
Add band switcher to header and context-aware logo link

### DIFF
--- a/app/band/[bandId]/layout.tsx
+++ b/app/band/[bandId]/layout.tsx
@@ -2,6 +2,7 @@
 
 import Loading from '@/components/design/Loading';
 import BandBreadcrumbs from '@/components/layout/BandBreadcrumbs';
+import BandSwitcher from '@/components/layout/BandSwitcher';
 import { useNav } from '@/components/layout/NavContext';
 import useBand from '@/hooks/useBand';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
@@ -140,6 +141,7 @@ export default function BandLayout({ children, params }: BandLayoutProps) {
             '& .MuiDrawer-paper': { width: SIDEBAR_WIDTH, boxSizing: 'border-box', ...sidebarSx },
           }}
         >
+          <BandSwitcher variant="drawer" onNavigate={() => setMobileOpen(false)} />
           {navList(() => setMobileOpen(false))}
         </Drawer>
 

--- a/components/layout/BandSwitcher.tsx
+++ b/components/layout/BandSwitcher.tsx
@@ -4,14 +4,14 @@ import useBands from '@/hooks/useBands';
 import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
-import { SxProps, Theme } from '@mui/material/styles';
 import { usePathname, useRouter } from 'next/navigation';
 
 interface BandSwitcherProps {
-  sx?: SxProps<Theme>;
+  variant?: 'appbar' | 'drawer';
+  onNavigate?: () => void;
 }
 
-export default function BandSwitcher({ sx }: BandSwitcherProps = {}) {
+export default function BandSwitcher({ variant = 'appbar', onNavigate }: BandSwitcherProps) {
   const pathname = usePathname();
   const router = useRouter();
   const bandMatch = pathname.match(/^\/band\/(\d+)/);
@@ -21,11 +21,30 @@ export default function BandSwitcher({ sx }: BandSwitcherProps = {}) {
 
   if (!currentBandId || !bands || bands.length <= 1) return null;
 
+  const bandItems = bands.map((band) => (
+    <MenuItem key={band.id} value={String(band.id)}>
+      {band.name}
+    </MenuItem>
+  ));
+
+  if (variant === 'drawer') {
+    return (
+      <FormControl size="small" fullWidth sx={{ mb: 2 }}>
+        <Select
+          value={currentBandId}
+          onChange={(e) => { router.push(`/band/${e.target.value as string}`); onNavigate?.(); }}
+        >
+          {bandItems}
+        </Select>
+      </FormControl>
+    );
+  }
+
   return (
-    <FormControl size="small" sx={{ minWidth: 140, ...sx }}>
+    <FormControl size="small" sx={{ minWidth: 140 }}>
       <Select
         value={currentBandId}
-        onChange={(e) => router.push(`/band/${e.target.value}`)}
+        onChange={(e) => { router.push(`/band/${e.target.value as string}`); onNavigate?.(); }}
         sx={{
           color: 'inherit',
           '.MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.4)' },
@@ -34,11 +53,7 @@ export default function BandSwitcher({ sx }: BandSwitcherProps = {}) {
           '.MuiSvgIcon-root': { color: 'inherit' },
         }}
       >
-        {bands.map((band) => (
-          <MenuItem key={band.id} value={String(band.id)}>
-            {band.name}
-          </MenuItem>
-        ))}
+        {bandItems}
       </Select>
     </FormControl>
   );

--- a/components/layout/BandSwitcher.tsx
+++ b/components/layout/BandSwitcher.tsx
@@ -3,10 +3,15 @@
 import useBands from '@/hooks/useBands';
 import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
+import Select from '@mui/material/Select';
+import { SxProps, Theme } from '@mui/material/styles';
 import { usePathname, useRouter } from 'next/navigation';
 
-export default function BandSwitcher() {
+interface BandSwitcherProps {
+  sx?: SxProps<Theme>;
+}
+
+export default function BandSwitcher({ sx }: BandSwitcherProps = {}) {
   const pathname = usePathname();
   const router = useRouter();
   const bandMatch = pathname.match(/^\/band\/(\d+)/);
@@ -16,15 +21,11 @@ export default function BandSwitcher() {
 
   if (!currentBandId || !bands || bands.length <= 1) return null;
 
-  const handleChange = (event: SelectChangeEvent) => {
-    router.push(`/band/${event.target.value}`);
-  };
-
   return (
-    <FormControl size="small" sx={{ minWidth: 140, mr: 1 }}>
+    <FormControl size="small" sx={{ minWidth: 140, ...sx }}>
       <Select
         value={currentBandId}
-        onChange={handleChange}
+        onChange={(e) => router.push(`/band/${e.target.value}`)}
         sx={{
           color: 'inherit',
           '.MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.4)' },

--- a/components/layout/BandSwitcher.tsx
+++ b/components/layout/BandSwitcher.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import useBands from '@/hooks/useBands';
+import FormControl from '@mui/material/FormControl';
+import MenuItem from '@mui/material/MenuItem';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import { usePathname, useRouter } from 'next/navigation';
+
+export default function BandSwitcher() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const bandMatch = pathname.match(/^\/band\/(\d+)/);
+  const currentBandId = bandMatch ? bandMatch[1] : null;
+
+  const { data: bands } = useBands();
+
+  if (!currentBandId || !bands || bands.length <= 1) return null;
+
+  const handleChange = (event: SelectChangeEvent) => {
+    router.push(`/band/${event.target.value}`);
+  };
+
+  return (
+    <FormControl size="small" sx={{ minWidth: 140, mr: 1 }}>
+      <Select
+        value={currentBandId}
+        onChange={handleChange}
+        sx={{
+          color: 'inherit',
+          '.MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.4)' },
+          '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.7)' },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: 'white' },
+          '.MuiSvgIcon-root': { color: 'inherit' },
+        }}
+      >
+        {bands.map((band) => (
+          <MenuItem key={band.id} value={String(band.id)}>
+            {band.name}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -10,16 +10,24 @@ import HeaderNavToggle from './HeaderNavToggle';
 export default function Header() {
   return (
     <AppBar position="static" sx={{ width: '100%' }}>
+      {/* Main toolbar row */}
       <Toolbar sx={{ width: '100%', px: { xs: 2, sm: 3 } }}>
         <HeaderNavToggle />
-        <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexGrow: 1 }}>
           <HeaderLogo />
+          {/* Band switcher inline with logo — desktop only */}
+          <Box sx={{ display: { xs: 'none', sm: 'flex' } }}>
+            <BandSwitcher />
+          </Box>
         </Box>
-        <BandSwitcher />
         <Suspense>
           <AuthButton />
         </Suspense>
       </Toolbar>
+      {/* Band switcher sub-row — mobile only */}
+      <Box sx={{ display: { xs: 'block', sm: 'none' }, px: 2, pb: 0.75 }}>
+        <BandSwitcher sx={{ minWidth: 0, width: 'auto' }} />
+      </Box>
     </AppBar>
   );
 }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -10,12 +10,11 @@ import HeaderNavToggle from './HeaderNavToggle';
 export default function Header() {
   return (
     <AppBar position="static" sx={{ width: '100%' }}>
-      {/* Main toolbar row */}
       <Toolbar sx={{ width: '100%', px: { xs: 2, sm: 3 } }}>
         <HeaderNavToggle />
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexGrow: 1 }}>
           <HeaderLogo />
-          {/* Band switcher inline with logo — desktop only */}
+          {/* Desktop only — on mobile the switcher lives inside the nav drawer */}
           <Box sx={{ display: { xs: 'none', sm: 'flex' } }}>
             <BandSwitcher />
           </Box>
@@ -24,10 +23,6 @@ export default function Header() {
           <AuthButton />
         </Suspense>
       </Toolbar>
-      {/* Band switcher sub-row — mobile only */}
-      <Box sx={{ display: { xs: 'block', sm: 'none' }, px: 2, pb: 0.75 }}>
-        <BandSwitcher sx={{ minWidth: 0, width: 'auto' }} />
-      </Box>
     </AppBar>
   );
 }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,11 +1,10 @@
-import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
-import Typography from '@mui/material/Typography';
-import Link from 'next/link';
 import { Suspense } from 'react';
 import AuthButton from './AuthButton';
+import BandSwitcher from './BandSwitcher';
+import HeaderLogo from './HeaderLogo';
 import HeaderNavToggle from './HeaderNavToggle';
 
 export default function Header() {
@@ -14,13 +13,9 @@ export default function Header() {
       <Toolbar sx={{ width: '100%', px: { xs: 2, sm: 3 } }}>
         <HeaderNavToggle />
         <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
-          <Link href="/" className="no-underline" style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'inherit' }}>
-            <MusicNoteIcon sx={{ fontSize: 26 }} />
-            <Typography variant="h6" component="h1" sx={{ fontWeight: 700, letterSpacing: '-0.02em' }}>
-              Band Manager
-            </Typography>
-          </Link>
+          <HeaderLogo />
         </Box>
+        <BandSwitcher />
         <Suspense>
           <AuthButton />
         </Suspense>

--- a/components/layout/HeaderLogo.tsx
+++ b/components/layout/HeaderLogo.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import MusicNoteIcon from '@mui/icons-material/MusicNote';
+import Typography from '@mui/material/Typography';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export default function HeaderLogo() {
+  const pathname = usePathname();
+  const bandMatch = pathname.match(/^\/band\/(\d+)/);
+  const href = bandMatch ? `/band/${bandMatch[1]}` : '/';
+
+  return (
+    <Link href={href} className="no-underline" style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'inherit' }}>
+      <MusicNoteIcon sx={{ fontSize: 26 }} />
+      <Typography variant="h6" component="h1" sx={{ fontWeight: 700, letterSpacing: '-0.02em' }}>
+        Band Manager
+      </Typography>
+    </Link>
+  );
+}


### PR DESCRIPTION
- Logo now links to the band overview (/band/[id]) when inside a band route, and to the bands picker (/) otherwise
- New BandSwitcher dropdown in the header lets users switch between bands without leaving the current app context; only shown when the user has more than one active band

https://claude.ai/code/session_01RMXmufbuEi8N12kurefzm4