### PR TITLE
Add 'Add another band' option to band switcher dropdown

### DIFF
--- a/components/forms/BandForm.tsx
+++ b/components/forms/BandForm.tsx
@@ -4,13 +4,15 @@ import { createClient } from '@/utils/supabase/client';
 import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
+import { mutate } from 'swr';
 import Form, { FormField } from '../design/Form';
 
 interface BandFormProps {
   bandId?: number;
+  onBandCreated?: (bandId: number) => void;
 }
 
-export default function BandForm({ bandId }: Readonly<BandFormProps>) {
+export default function BandForm({ bandId, onBandCreated }: Readonly<BandFormProps>) {
   const [errorMessage, setErrorMessage] = useState<string>();
 
   const supabase = createClient();
@@ -31,14 +33,19 @@ export default function BandForm({ bandId }: Readonly<BandFormProps>) {
 
   async function onSuccess(data: FieldValues) {
     if (!bandId) {
-      const { error } = await supabase.rpc('create_band_with_member', {
+      const { data: newBandId, error } = await supabase.rpc('create_band_with_member', {
         band_name: data.name,
       });
       if (error) {
         setErrorMessage(error.message);
         return;
       }
-      router.push('/');
+      await mutate('my-bands-active');
+      if (onBandCreated && typeof newBandId === 'number') {
+        onBandCreated(newBandId);
+      } else {
+        router.push('/');
+      }
     }
   }
 

--- a/components/layout/BandSwitcher.tsx
+++ b/components/layout/BandSwitcher.tsx
@@ -1,10 +1,16 @@
 'use client';
 
+import BandForm from '@/components/forms/BandForm';
 import useBands from '@/hooks/useBands';
+import Divider from '@mui/material/Divider';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
 import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import { usePathname, useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 interface BandSwitcherProps {
   variant?: 'appbar' | 'drawer';
@@ -16,10 +22,26 @@ export default function BandSwitcher({ variant = 'appbar', onNavigate }: BandSwi
   const router = useRouter();
   const bandMatch = pathname.match(/^\/band\/(\d+)/);
   const currentBandId = bandMatch ? bandMatch[1] : null;
+  const [addBandOpen, setAddBandOpen] = useState(false);
 
   const { data: bands } = useBands();
 
-  if (!currentBandId || !bands || bands.length <= 1) return null;
+  if (!currentBandId || !bands || bands.length < 1) return null;
+
+  const handleChange = (value: string) => {
+    if (value === 'add-band') {
+      setAddBandOpen(true);
+    } else {
+      router.push(`/band/${value}`);
+      onNavigate?.();
+    }
+  };
+
+  const handleBandCreated = (newBandId: number) => {
+    setAddBandOpen(false);
+    router.push(`/band/${newBandId}`);
+    onNavigate?.();
+  };
 
   const bandItems = bands.map((band) => (
     <MenuItem key={band.id} value={String(band.id)}>
@@ -27,34 +49,57 @@ export default function BandSwitcher({ variant = 'appbar', onNavigate }: BandSwi
     </MenuItem>
   ));
 
+  const addBandModal = (
+    <Dialog open={addBandOpen} onClose={() => setAddBandOpen(false)}>
+      <DialogTitle>Add another band</DialogTitle>
+      <DialogContent>
+        <BandForm onBandCreated={handleBandCreated} />
+      </DialogContent>
+    </Dialog>
+  );
+
   if (variant === 'drawer') {
     return (
-      <FormControl size="small" fullWidth sx={{ mb: 2 }}>
-        <Select
-          value={currentBandId}
-          onChange={(e) => { router.push(`/band/${e.target.value as string}`); onNavigate?.(); }}
-        >
-          {bandItems}
-        </Select>
-      </FormControl>
+      <>
+        <FormControl size="small" fullWidth sx={{ mb: 2 }}>
+          <Select
+            value={currentBandId}
+            onChange={(e) => handleChange(e.target.value as string)}
+          >
+            {bandItems}
+            <Divider />
+            <MenuItem value="add-band" sx={{ color: 'primary.main' }}>
+              Add another band
+            </MenuItem>
+          </Select>
+        </FormControl>
+        {addBandModal}
+      </>
     );
   }
 
   return (
-    <FormControl size="small" sx={{ minWidth: 140 }}>
-      <Select
-        value={currentBandId}
-        onChange={(e) => { router.push(`/band/${e.target.value as string}`); onNavigate?.(); }}
-        sx={{
-          color: 'inherit',
-          '.MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.4)' },
-          '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.7)' },
-          '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: 'white' },
-          '.MuiSvgIcon-root': { color: 'inherit' },
-        }}
-      >
-        {bandItems}
-      </Select>
-    </FormControl>
+    <>
+      <FormControl size="small" sx={{ minWidth: 140 }}>
+        <Select
+          value={currentBandId}
+          onChange={(e) => handleChange(e.target.value as string)}
+          sx={{
+            color: 'inherit',
+            '.MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.4)' },
+            '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.7)' },
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: 'white' },
+            '.MuiSvgIcon-root': { color: 'inherit' },
+          }}
+        >
+          {bandItems}
+          <Divider />
+          <MenuItem value="add-band" sx={{ color: 'primary.main' }}>
+            Add another band
+          </MenuItem>
+        </Select>
+      </FormControl>
+      {addBandModal}
+    </>
   );
 }


### PR DESCRIPTION
Adds a visually separate 'Add another band' item at the bottom of the
band switcher dropdown (both appbar and drawer variants). Clicking it
opens a modal with the band creation form; on success the user is
automatically switched into the newly created band.

https://claude.ai/code/session_0191sMN7eMvD9FNsH255zeUy