### PR TITLE
Add Spotify song search to Add Song form

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,3 +2,8 @@
 # https://app.supabase.com/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# Optional: Spotify integration (enables song search in the Add Song form)
+# Get these from https://developer.spotify.com/dashboard
+NEXT_PUBLIC_SPOTIFY_API_KEY=your-spotify-client-id
+SPOTIFY_CLIENT_SECRET=your-spotify-client-secret

--- a/app/api/spotify/search/route.ts
+++ b/app/api/spotify/search/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('q');
+
+  if (!query?.trim()) {
+    return NextResponse.json({ error: 'Missing query' }, { status: 400 });
+  }
+
+  const clientId = process.env.NEXT_PUBLIC_SPOTIFY_API_KEY;
+  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    return NextResponse.json({ error: 'Spotify not configured' }, { status: 503 });
+  }
+
+  const tokenResponse = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+    },
+    body: 'grant_type=client_credentials',
+  });
+
+  if (!tokenResponse.ok) {
+    return NextResponse.json({ error: 'Failed to authenticate with Spotify' }, { status: 502 });
+  }
+
+  const { access_token } = await tokenResponse.json();
+
+  const searchResponse = await fetch(
+    `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&limit=10`,
+    { headers: { Authorization: `Bearer ${access_token}` } }
+  );
+
+  if (!searchResponse.ok) {
+    return NextResponse.json({ error: 'Spotify search failed' }, { status: 502 });
+  }
+
+  const data = await searchResponse.json();
+  return NextResponse.json(data.tracks.items);
+}

--- a/app/band/[bandId]/practice/page.tsx
+++ b/app/band/[bandId]/practice/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import SpotifyBadge from '@/components/SpotifyBadge';
 import Loading from '@/components/design/Loading';
 import ChordChartViewModal from '@/components/modals/ChordChartViewModal';
 import usePracticeProgress from '@/hooks/usePracticeProgress';
@@ -382,7 +383,10 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
                   </TableCell>
                 )}
                 <TableCell component="th" scope="row">
-                  <Typography fontWeight={600}>{song.name}</Typography>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography fontWeight={600}>{song.name}</Typography>
+                    {song.spotify_url && <SpotifyBadge spotifyUrl={song.spotify_url} />}
+                  </Box>
                   {song.artist && (
                     <Typography variant="body2" color="text.secondary">
                       {song.artist}

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -6,6 +6,7 @@ import Table, { TableProps, TablePropsDataType, TableRow } from '@/components/de
 import EditSongForm from '@/components/forms/EditSongForm';
 import SongCommentForm from '@/components/forms/SongCommentForm';
 import AddSongModal from '@/components/modals/AddSongModal';
+import SpotifyBadge from '@/components/SpotifyBadge';
 import useSongs, { SongsComposite } from '@/hooks/useSongs';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import EditIcon from '@mui/icons-material/Edit';
@@ -127,6 +128,15 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
     });
   }
 
+  function formatName(value: TablePropsDataType, row: TableRow) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <span>{value as string}</span>
+        {row.spotify_url && <SpotifyBadge spotifyUrl={row.spotify_url as string} />}
+      </Box>
+    );
+  }
+
   function formatActions(_value: TablePropsDataType | null, row: TableRow) {
     const song = songs?.find((s) => s.id === row.id);
     if (!song) return '';
@@ -145,6 +155,7 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
       name: song.name,
       artist: song.artist,
       duration: song.duration,
+      spotify_url: song.spotify_url,
     }));
 
     const q = searchQuery.toLowerCase();
@@ -174,6 +185,7 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
         {
           name: 'Name',
           dataKey: 'name',
+          dataFormatter: formatName,
           isHeader: true,
           headerDataKey: 'id',
           sortable: true,

--- a/components/SpotifyBadge.tsx
+++ b/components/SpotifyBadge.tsx
@@ -1,27 +1,42 @@
-import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
 
 interface SpotifyBadgeProps {
   spotifyUrl: string;
+  size?: number;
 }
 
-export default function SpotifyBadge({ spotifyUrl }: Readonly<SpotifyBadgeProps>) {
+// Official Spotify icon SVG per Spotify brand guidelines:
+// https://developer.spotify.com/documentation/design#using-our-logo
+function SpotifyIcon({ size }: { size: number }) {
   return (
-    <Chip
-      component="a"
-      href={spotifyUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      label="Spotify"
-      size="small"
-      clickable
-      sx={{
-        backgroundColor: '#1DB954',
-        color: '#fff',
-        fontWeight: 700,
-        fontSize: '0.65rem',
-        letterSpacing: '0.04em',
-        '&:hover': { backgroundColor: '#17a349' },
-      }}
-    />
+    <svg
+      role="img"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      aria-label="Spotify"
+    >
+      <path
+        fill="#1DB954"
+        d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"
+      />
+    </svg>
+  );
+}
+
+export default function SpotifyBadge({ spotifyUrl, size = 20 }: Readonly<SpotifyBadgeProps>) {
+  return (
+    <Tooltip title="Listen on Spotify">
+      <a
+        href={spotifyUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}
+        aria-label="Listen on Spotify"
+      >
+        <SpotifyIcon size={size} />
+      </a>
+    </Tooltip>
   );
 }

--- a/components/SpotifyBadge.tsx
+++ b/components/SpotifyBadge.tsx
@@ -1,0 +1,27 @@
+import Chip from '@mui/material/Chip';
+
+interface SpotifyBadgeProps {
+  spotifyUrl: string;
+}
+
+export default function SpotifyBadge({ spotifyUrl }: Readonly<SpotifyBadgeProps>) {
+  return (
+    <Chip
+      component="a"
+      href={spotifyUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      label="Spotify"
+      size="small"
+      clickable
+      sx={{
+        backgroundColor: '#1DB954',
+        color: '#fff',
+        fontWeight: 700,
+        fontSize: '0.65rem',
+        letterSpacing: '0.04em',
+        '&:hover': { backgroundColor: '#17a349' },
+      }}
+    />
+  );
+}

--- a/components/SpotifyBadge.tsx
+++ b/components/SpotifyBadge.tsx
@@ -1,13 +1,8 @@
 import Tooltip from '@mui/material/Tooltip';
 
-interface SpotifyBadgeProps {
-  spotifyUrl: string;
-  size?: number;
-}
-
 // Official Spotify icon SVG per Spotify brand guidelines:
 // https://developer.spotify.com/documentation/design#using-our-logo
-function SpotifyIcon({ size }: { size: number }) {
+export function SpotifyIcon({ size = 20 }: Readonly<{ size?: number }>) {
   return (
     <svg
       role="img"
@@ -16,6 +11,7 @@ function SpotifyIcon({ size }: { size: number }) {
       width={size}
       height={size}
       aria-label="Spotify"
+      style={{ flexShrink: 0 }}
     >
       <path
         fill="#1DB954"
@@ -23,6 +19,11 @@ function SpotifyIcon({ size }: { size: number }) {
       />
     </svg>
   );
+}
+
+interface SpotifyBadgeProps {
+  spotifyUrl: string;
+  size?: number;
 }
 
 export default function SpotifyBadge({ spotifyUrl, size = 20 }: Readonly<SpotifyBadgeProps>) {

--- a/components/SpotifyTrackSearch.tsx
+++ b/components/SpotifyTrackSearch.tsx
@@ -70,20 +70,18 @@ export default function SpotifyTrackSearch({ onSelect }: Readonly<SpotifyTrackSe
         onKeyDown={handleKeyDown}
         fullWidth
         className="mb-2"
-        slotProps={{
-          input: {
-            endAdornment: (
-              <InputAdornment position="end">
-                {loading ? (
-                  <CircularProgress size={20} />
-                ) : (
-                  <IconButton onClick={handleSearch} edge="end" aria-label="search spotify">
-                    <SearchIcon />
-                  </IconButton>
-                )}
-              </InputAdornment>
-            ),
-          },
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              {loading ? (
+                <CircularProgress size={20} />
+              ) : (
+                <IconButton onClick={handleSearch} edge="end" aria-label="search spotify">
+                  <SearchIcon />
+                </IconButton>
+              )}
+            </InputAdornment>
+          ),
         }}
       />
       {error && (

--- a/components/SpotifyTrackSearch.tsx
+++ b/components/SpotifyTrackSearch.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { formatMsToDuration } from '@/utils/songs';
+import SearchIcon from '@mui/icons-material/Search';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Image from 'next/image';
+import { useState } from 'react';
+
+export interface SpotifyTrack {
+  id: string;
+  name: string;
+  artists: Array<{ name: string }>;
+  album: {
+    name: string;
+    images: Array<{ url: string; width: number; height: number }>;
+  };
+  duration_ms: number;
+  external_urls: { spotify: string };
+}
+
+interface SpotifyTrackSearchProps {
+  onSelect: (track: SpotifyTrack) => void;
+}
+
+export default function SpotifyTrackSearch({ onSelect }: Readonly<SpotifyTrackSearchProps>) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SpotifyTrack[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [searched, setSearched] = useState(false);
+
+  async function handleSearch() {
+    if (!query.trim()) return;
+    setLoading(true);
+    setError(undefined);
+    setSearched(true);
+
+    const response = await fetch(`/api/spotify/search?q=${encodeURIComponent(query)}`);
+    if (response.ok) {
+      const tracks = await response.json();
+      setResults(tracks);
+    } else if (response.status === 503) {
+      setError('Spotify search is not configured.');
+    } else {
+      setError('Search failed. Please try again.');
+    }
+    setLoading(false);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSearch();
+    }
+  }
+
+  return (
+    <div>
+      <TextField
+        label="Search Spotify"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+        fullWidth
+        className="mb-2"
+        slotProps={{
+          input: {
+            endAdornment: (
+              <InputAdornment position="end">
+                {loading ? (
+                  <CircularProgress size={20} />
+                ) : (
+                  <IconButton onClick={handleSearch} edge="end" aria-label="search spotify">
+                    <SearchIcon />
+                  </IconButton>
+                )}
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+      {error && (
+        <Typography color="error" variant="body2" className="mb-2">
+          {error}
+        </Typography>
+      )}
+      {searched && !loading && results.length === 0 && !error && (
+        <Typography variant="body2" color="text.secondary" className="mb-2">
+          No results found.
+        </Typography>
+      )}
+      {results.length > 0 && (
+        <List
+          dense
+          sx={{
+            maxHeight: 280,
+            overflowY: 'auto',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            mb: 2,
+          }}
+        >
+          {results.map((track) => {
+            const thumbnail = track.album.images.at(-1);
+            const artistNames = track.artists.map((a) => a.name).join(', ');
+            const duration = formatMsToDuration(track.duration_ms);
+
+            return (
+              <ListItemButton key={track.id} onClick={() => onSelect(track)} alignItems="flex-start">
+                {thumbnail && (
+                  <Image
+                    src={thumbnail.url}
+                    alt={track.album.name}
+                    width={40}
+                    height={40}
+                    style={{ borderRadius: 4, marginRight: 12, flexShrink: 0 }}
+                  />
+                )}
+                <ListItemText
+                  primary={track.name}
+                  secondary={`${artistNames} · ${duration}`}
+                />
+              </ListItemButton>
+            );
+          })}
+        </List>
+      )}
+    </div>
+  );
+}

--- a/components/SpotifyTrackSearch.tsx
+++ b/components/SpotifyTrackSearch.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { SpotifyIcon } from '@/components/SpotifyBadge';
-import { cleanSpotifyTrackName, formatMsToDuration } from '@/utils/songs';
+import { formatMsToDuration } from '@/utils/songs';
 import CircularProgress from '@mui/material/CircularProgress';
 import InputAdornment from '@mui/material/InputAdornment';
 import List from '@mui/material/List';
@@ -131,7 +131,7 @@ export default function SpotifyTrackSearch({ onSelect, initialQuery = '' }: Read
                   />
                 )}
                 <ListItemText
-                  primary={cleanSpotifyTrackName(track.name)}
+                  primary={track.name}
                   secondary={`${artistNames} · ${duration}`}
                 />
               </ListItemButton>

--- a/components/SpotifyTrackSearch.tsx
+++ b/components/SpotifyTrackSearch.tsx
@@ -25,13 +25,14 @@ export interface SpotifyTrack {
 
 interface SpotifyTrackSearchProps {
   onSelect: (track: SpotifyTrack) => void;
+  initialQuery?: string;
 }
 
 const DEBOUNCE_MS = 500;
 const MIN_QUERY_LENGTH = 2;
 
-export default function SpotifyTrackSearch({ onSelect }: Readonly<SpotifyTrackSearchProps>) {
-  const [query, setQuery] = useState('');
+export default function SpotifyTrackSearch({ onSelect, initialQuery = '' }: Readonly<SpotifyTrackSearchProps>) {
+  const [query, setQuery] = useState(initialQuery);
   const [results, setResults] = useState<SpotifyTrack[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();

--- a/components/SpotifyTrackSearch.tsx
+++ b/components/SpotifyTrackSearch.tsx
@@ -132,7 +132,7 @@ export default function SpotifyTrackSearch({ onSelect, initialQuery = '' }: Read
                 )}
                 <ListItemText
                   primary={track.name}
-                  secondary={`${artistNames} · ${duration}`}
+                  secondary={`${artistNames} · ${track.album.name} · ${duration}`}
                 />
               </ListItemButton>
             );

--- a/components/SpotifyTrackSearch.tsx
+++ b/components/SpotifyTrackSearch.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { formatMsToDuration } from '@/utils/songs';
+import { SpotifyIcon } from '@/components/SpotifyBadge';
+import { cleanSpotifyTrackName, formatMsToDuration } from '@/utils/songs';
 import CircularProgress from '@mui/material/CircularProgress';
 import InputAdornment from '@mui/material/InputAdornment';
 import List from '@mui/material/List';
@@ -79,6 +80,11 @@ export default function SpotifyTrackSearch({ onSelect, initialQuery = '' }: Read
         fullWidth
         className="mb-2"
         InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SpotifyIcon size={18} />
+            </InputAdornment>
+          ),
           endAdornment: loading ? (
             <InputAdornment position="end">
               <CircularProgress size={20} />
@@ -125,7 +131,7 @@ export default function SpotifyTrackSearch({ onSelect, initialQuery = '' }: Read
                   />
                 )}
                 <ListItemText
-                  primary={track.name}
+                  primary={cleanSpotifyTrackName(track.name)}
                   secondary={`${artistNames} · ${duration}`}
                 />
               </ListItemButton>

--- a/components/SpotifyTrackSearch.tsx
+++ b/components/SpotifyTrackSearch.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import { formatMsToDuration } from '@/utils/songs';
-import SearchIcon from '@mui/icons-material/Search';
 import CircularProgress from '@mui/material/CircularProgress';
-import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -11,7 +9,7 @@ import ListItemText from '@mui/material/ListItemText';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export interface SpotifyTrack {
   id: string;
@@ -29,37 +27,47 @@ interface SpotifyTrackSearchProps {
   onSelect: (track: SpotifyTrack) => void;
 }
 
+const DEBOUNCE_MS = 500;
+const MIN_QUERY_LENGTH = 2;
+
 export default function SpotifyTrackSearch({ onSelect }: Readonly<SpotifyTrackSearchProps>) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SpotifyTrack[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [searched, setSearched] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  async function handleSearch() {
-    if (!query.trim()) return;
-    setLoading(true);
-    setError(undefined);
-    setSearched(true);
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
 
-    const response = await fetch(`/api/spotify/search?q=${encodeURIComponent(query)}`);
-    if (response.ok) {
-      const tracks = await response.json();
-      setResults(tracks);
-    } else if (response.status === 503) {
-      setError('Spotify search is not configured.');
-    } else {
-      setError('Search failed. Please try again.');
+    if (query.trim().length < MIN_QUERY_LENGTH) {
+      setResults([]);
+      setSearched(false);
+      setError(undefined);
+      return;
     }
-    setLoading(false);
-  }
 
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      handleSearch();
-    }
-  }
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true);
+      setError(undefined);
+      setSearched(true);
+
+      const response = await fetch(`/api/spotify/search?q=${encodeURIComponent(query)}`);
+      if (response.ok) {
+        setResults(await response.json());
+      } else if (response.status === 503) {
+        setError('Spotify search is not configured.');
+      } else {
+        setError('Search failed. Please try again.');
+      }
+      setLoading(false);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query]);
 
   return (
     <div>
@@ -67,21 +75,14 @@ export default function SpotifyTrackSearch({ onSelect }: Readonly<SpotifyTrackSe
         label="Search Spotify"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
-        onKeyDown={handleKeyDown}
         fullWidth
         className="mb-2"
         InputProps={{
-          endAdornment: (
+          endAdornment: loading ? (
             <InputAdornment position="end">
-              {loading ? (
-                <CircularProgress size={20} />
-              ) : (
-                <IconButton onClick={handleSearch} edge="end" aria-label="search spotify">
-                  <SearchIcon />
-                </IconButton>
-              )}
+              <CircularProgress size={20} />
             </InputAdornment>
-          ),
+          ) : null,
         }}
       />
       {error && (

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -3,10 +3,16 @@
 import SpotifyTrackSearch, { SpotifyTrack } from '@/components/SpotifyTrackSearch';
 import { createClient } from '@/utils/supabase/client';
 import { formatMsToDuration, parseDurationToMs } from '@/utils/songs';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import CloseIcon from '@mui/icons-material/Close';
-import Chip from '@mui/material/Chip';
+import SaveIcon from '@mui/icons-material/Save';
+import SearchIcon from '@mui/icons-material/Search';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
+import LoadingButton from '@mui/lab/LoadingButton';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useMemo, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
@@ -17,14 +23,17 @@ interface AddSongFormProps {
   onSuccess?: () => void;
 }
 
+type Mode = 'spotify' | 'manual';
+
 export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormProps>) {
-  const [errorMessage, setErrorMessage] = useState<string>();
+  const [mode, setMode] = useState<Mode>('spotify');
   const [selectedTrack, setSelectedTrack] = useState<SpotifyTrack | null>(null);
-  const [formKey, setFormKey] = useState(0);
-  const [defaultValues, setDefaultValues] = useState<Record<string, string>>({});
+  const [chordChart, setChordChart] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
   const supabase = createClient();
 
-  const formFields: FormField[] = useMemo(
+  const manualFormFields: FormField[] = useMemo(
     () => [
       {
         fieldType: 'text' as FormField['fieldType'],
@@ -58,24 +67,29 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
     []
   );
 
-  function handleSpotifySelect(track: SpotifyTrack) {
-    setSelectedTrack(track);
-    setDefaultValues({
-      name: track.name,
-      artist: track.artists.map((a) => a.name).join(', '),
-      duration: formatMsToDuration(track.duration_ms),
-      chord_chart: '',
+  async function handleSpotifySubmit() {
+    if (!selectedTrack) return;
+    setIsSubmitting(true);
+    setErrorMessage('');
+
+    const { error } = await supabase.from('songs').insert({
+      name: selectedTrack.name,
+      artist: selectedTrack.artists.map((a) => a.name).join(', '),
+      duration: selectedTrack.duration_ms,
+      chord_chart: chordChart || null,
+      band_id: bandId,
+      spotify_url: selectedTrack.external_urls.spotify,
     });
-    setFormKey((k) => k + 1);
+
+    setIsSubmitting(false);
+    if (error) {
+      setErrorMessage(error.message);
+    } else {
+      onSuccess?.();
+    }
   }
 
-  function handleClearSpotify() {
-    setSelectedTrack(null);
-    setDefaultValues({});
-    setFormKey((k) => k + 1);
-  }
-
-  async function handleSuccess(data: FieldValues) {
+  async function handleManualSuccess(data: FieldValues) {
     setErrorMessage('');
 
     const duration = data.duration ? parseDurationToMs(data.duration) : null;
@@ -90,7 +104,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
       duration,
       chord_chart: data.chord_chart || null,
       band_id: bandId,
-      spotify_url: selectedTrack?.external_urls.spotify ?? null,
+      spotify_url: null,
     });
 
     if (error) {
@@ -100,33 +114,82 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
     }
   }
 
+  function handleTabChange(_: React.SyntheticEvent, newMode: Mode) {
+    setMode(newMode);
+    setSelectedTrack(null);
+    setChordChart('');
+    setErrorMessage('');
+  }
+
   return (
     <>
-      <SpotifyTrackSearch onSelect={handleSpotifySelect} />
-      {selectedTrack && (
-        <Chip
-          icon={<CheckCircleIcon />}
-          label={`${selectedTrack.name} — ${selectedTrack.artists.map((a) => a.name).join(', ')}`}
-          onDelete={handleClearSpotify}
-          deleteIcon={<CloseIcon />}
-          color="success"
-          variant="outlined"
-          className="mb-4"
+      <Tabs value={mode} onChange={handleTabChange} className="mb-4">
+        <Tab icon={<SearchIcon fontSize="small" />} iconPosition="start" label="Search Spotify" value="spotify" />
+        <Tab label="Manual Entry" value="manual" />
+      </Tabs>
+
+      {mode === 'spotify' && (
+        <>
+          {!selectedTrack ? (
+            <SpotifyTrackSearch onSelect={setSelectedTrack} />
+          ) : (
+            <>
+              <Box className="mb-4" sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                  Selected song
+                </Typography>
+                <Typography variant="h6" component="p">
+                  {selectedTrack.name}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {selectedTrack.artists.map((a) => a.name).join(', ')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {formatMsToDuration(selectedTrack.duration_ms)}
+                </Typography>
+              </Box>
+              <Divider className="mb-4" />
+              <TextField
+                label="Chord Chart"
+                value={chordChart}
+                onChange={(e) => setChordChart(e.target.value)}
+                fullWidth
+                multiline
+                rows={10}
+                className="mb-4"
+                inputProps={{ style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } }}
+              />
+              {errorMessage && (
+                <Alert severity="error" className="mb-4">
+                  {errorMessage}
+                </Alert>
+              )}
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Button variant="outlined" onClick={() => setSelectedTrack(null)}>
+                  Search Again
+                </Button>
+                <LoadingButton
+                  variant="contained"
+                  loading={isSubmitting}
+                  startIcon={<SaveIcon />}
+                  onClick={handleSpotifySubmit}
+                >
+                  Add Song
+                </LoadingButton>
+              </Box>
+            </>
+          )}
+        </>
+      )}
+
+      {mode === 'manual' && (
+        <Form
+          onSuccess={handleManualSuccess}
+          formFields={manualFormFields}
+          errorMessage={errorMessage}
+          saveButtonLabel="Add Song"
         />
       )}
-      <Divider className="mb-4">
-        <Typography variant="caption" color="text.secondary">
-          {selectedTrack ? 'Edit song details' : 'Or enter details manually'}
-        </Typography>
-      </Divider>
-      <Form
-        key={formKey}
-        onSuccess={handleSuccess}
-        formFields={formFields}
-        defaultValues={defaultValues}
-        errorMessage={errorMessage}
-        saveButtonLabel="Add Song"
-      />
     </>
   );
 }

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -1,4 +1,13 @@
+'use client';
+
+import SpotifyTrackSearch, { SpotifyTrack } from '@/components/SpotifyTrackSearch';
 import { createClient } from '@/utils/supabase/client';
+import { formatMsToDuration, parseDurationToMs } from '@/utils/songs';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CloseIcon from '@mui/icons-material/Close';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
 import { useMemo, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 import Form, { FormField } from '../design/Form';
@@ -8,16 +17,11 @@ interface AddSongFormProps {
   onSuccess?: () => void;
 }
 
-function parseDurationToMs(value: string): number | null {
-  const match = value.trim().match(/^(\d+):([0-5]\d)$/);
-  if (!match) return null;
-  const minutes = parseInt(match[1], 10);
-  const seconds = parseInt(match[2], 10);
-  return (minutes * 60 + seconds) * 1000;
-}
-
 export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormProps>) {
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [selectedTrack, setSelectedTrack] = useState<SpotifyTrack | null>(null);
+  const [formKey, setFormKey] = useState(0);
+  const [defaultValues, setDefaultValues] = useState<Record<string, string>>({});
   const supabase = createClient();
 
   const formFields: FormField[] = useMemo(
@@ -54,6 +58,23 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
     []
   );
 
+  function handleSpotifySelect(track: SpotifyTrack) {
+    setSelectedTrack(track);
+    setDefaultValues({
+      name: track.name,
+      artist: track.artists.map((a) => a.name).join(', '),
+      duration: formatMsToDuration(track.duration_ms),
+      chord_chart: '',
+    });
+    setFormKey((k) => k + 1);
+  }
+
+  function handleClearSpotify() {
+    setSelectedTrack(null);
+    setDefaultValues({});
+    setFormKey((k) => k + 1);
+  }
+
   async function handleSuccess(data: FieldValues) {
     setErrorMessage('');
 
@@ -69,6 +90,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
       duration,
       chord_chart: data.chord_chart || null,
       band_id: bandId,
+      spotify_url: selectedTrack?.external_urls.spotify ?? null,
     });
 
     if (error) {
@@ -78,5 +100,33 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
     }
   }
 
-  return <Form onSuccess={handleSuccess} formFields={formFields} errorMessage={errorMessage} saveButtonLabel="Add Song" />;
+  return (
+    <>
+      <SpotifyTrackSearch onSelect={handleSpotifySelect} />
+      {selectedTrack && (
+        <Chip
+          icon={<CheckCircleIcon />}
+          label={`${selectedTrack.name} — ${selectedTrack.artists.map((a) => a.name).join(', ')}`}
+          onDelete={handleClearSpotify}
+          deleteIcon={<CloseIcon />}
+          color="success"
+          variant="outlined"
+          className="mb-4"
+        />
+      )}
+      <Divider className="mb-4">
+        <Typography variant="caption" color="text.secondary">
+          {selectedTrack ? 'Edit song details' : 'Or enter details manually'}
+        </Typography>
+      </Divider>
+      <Form
+        key={formKey}
+        onSuccess={handleSuccess}
+        formFields={formFields}
+        defaultValues={defaultValues}
+        errorMessage={errorMessage}
+        saveButtonLabel="Add Song"
+      />
+    </>
+  );
 }

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -124,7 +124,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
   return (
     <>
       <Tabs value={mode} onChange={handleTabChange} className="mb-4">
-        <Tab icon={<SpotifyIcon size={16} />} iconPosition="start" label="Search Spotify" value="spotify" />
+        <Tab icon={<span style={{ marginRight: 6, display: 'inline-flex' }}><SpotifyIcon size={16} /></span>} iconPosition="start" label="Search Spotify" value="spotify" />
         <Tab label="Manual Entry" value="manual" />
       </Tabs>
 

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { SpotifyIcon } from '@/components/SpotifyBadge';
 import SpotifyTrackSearch, { SpotifyTrack } from '@/components/SpotifyTrackSearch';
 import { createClient } from '@/utils/supabase/client';
-import { formatMsToDuration, parseDurationToMs } from '@/utils/songs';
+import { cleanSpotifyTrackName, formatMsToDuration, parseDurationToMs } from '@/utils/songs';
 import SaveIcon from '@mui/icons-material/Save';
-import SearchIcon from '@mui/icons-material/Search';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -73,7 +73,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
     setErrorMessage('');
 
     const { error } = await supabase.from('songs').insert({
-      name: selectedTrack.name,
+      name: cleanSpotifyTrackName(selectedTrack.name),
       artist: selectedTrack.artists.map((a) => a.name).join(', '),
       duration: selectedTrack.duration_ms,
       chord_chart: chordChart || null,
@@ -124,7 +124,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
   return (
     <>
       <Tabs value={mode} onChange={handleTabChange} className="mb-4">
-        <Tab icon={<SearchIcon fontSize="small" />} iconPosition="start" label="Search Spotify" value="spotify" />
+        <Tab icon={<SpotifyIcon size={16} />} iconPosition="start" label="Search Spotify" value="spotify" />
         <Tab label="Manual Entry" value="manual" />
       </Tabs>
 
@@ -139,7 +139,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
                   Selected song
                 </Typography>
                 <Typography variant="h6" component="p">
-                  {selectedTrack.name}
+                  {cleanSpotifyTrackName(selectedTrack.name)}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   {selectedTrack.artists.map((a) => a.name).join(', ')}

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -25,7 +25,7 @@ interface EditSongFormProps {
 }
 
 type Mode = 'spotify' | 'manual';
-type LinkedAction = null | 're-search' | 'confirm-unlink';
+type LinkedAction = null | 're-search' | 'confirm-unlink' | 'manual-edit';
 
 const chordChartField: FormField = {
   fieldType: 'textarea',
@@ -154,14 +154,26 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
     }
   }
 
-  async function handleUnlink() {
-    setIsSubmitting(true);
+  async function handleManualEditSuccess(data: FieldValues) {
     setErrorMessage('');
+
+    const duration = data.duration ? parseDurationToMs(data.duration) : null;
+    if (data.duration && duration === null) {
+      setErrorMessage('Invalid duration format. Use m:ss (e.g. 3:45).');
+      return;
+    }
+
     const { error } = await supabase
       .from('songs')
-      .update({ spotify_url: null })
+      .update({
+        name: data.name,
+        artist: data.artist || null,
+        duration,
+        chord_chart: data.chord_chart || null,
+        spotify_url: null,
+      })
       .eq('id', song.id);
-    setIsSubmitting(false);
+
     if (error) {
       setErrorMessage(error.message);
     } else {
@@ -171,6 +183,19 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
 
   // Already linked to Spotify
   if (isSpotifyLinked) {
+    // Confirmed unlink: show manual form; spotify_url removed only on save
+    if (linkedAction === 'manual-edit') {
+      return (
+        <Form
+          onSuccess={handleManualEditSuccess}
+          formFields={manualFormFields}
+          defaultValues={defaultValues}
+          errorMessage={errorMessage}
+          saveButtonLabel="Save Changes"
+        />
+      );
+    }
+
     // Unlink confirmation
     if (linkedAction === 'confirm-unlink') {
       return (
@@ -180,23 +205,17 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
             to edit the name, artist, and duration freely, but the song will no longer be linked to
             Spotify.
           </Alert>
-          {errorMessage && (
-            <Alert severity="error" className="mb-4">
-              {errorMessage}
-            </Alert>
-          )}
           <Box sx={{ display: 'flex', gap: 1 }}>
             <Button variant="outlined" onClick={() => setLinkedAction(null)}>
               Cancel
             </Button>
-            <LoadingButton
+            <Button
               variant="contained"
               color="warning"
-              loading={isSubmitting}
-              onClick={handleUnlink}
+              onClick={() => setLinkedAction('manual-edit')}
             >
               Confirm — Switch to Manual
-            </LoadingButton>
+            </Button>
           </Box>
         </>
       );

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -323,7 +323,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
   return (
     <>
       <Tabs value={mode} onChange={handleTabChange} className="mb-4">
-        <Tab icon={<SpotifyIcon size={16} />} iconPosition="start" label="Search Spotify" value="spotify" />
+        <Tab icon={<span style={{ marginRight: 6, display: 'inline-flex' }}><SpotifyIcon size={16} /></span>} iconPosition="start" label="Search Spotify" value="spotify" />
         <Tab label="Manual Entry" value="manual" />
       </Tabs>
 

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -1,9 +1,20 @@
+'use client';
+
 import SpotifyBadge from '@/components/SpotifyBadge';
+import SpotifyTrackSearch, { SpotifyTrack } from '@/components/SpotifyTrackSearch';
 import { Tables } from '@/types/supabase';
 import { createClient } from '@/utils/supabase/client';
 import { formatMsToDuration, parseDurationToMs } from '@/utils/songs';
+import SaveIcon from '@mui/icons-material/Save';
+import SearchIcon from '@mui/icons-material/Search';
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
+import LoadingButton from '@mui/lab/LoadingButton';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useMemo, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
@@ -13,6 +24,8 @@ interface EditSongFormProps {
   song: Tables<'songs'>;
   onSuccess?: () => void;
 }
+
+type Mode = 'spotify' | 'manual';
 
 const chordChartField: FormField = {
   fieldType: 'textarea',
@@ -24,9 +37,15 @@ const chordChartField: FormField = {
 };
 
 export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormProps>) {
+  const [mode, setMode] = useState<Mode>('manual');
+  const [selectedTrack, setSelectedTrack] = useState<SpotifyTrack | null>(null);
+  const [chordChart, setChordChart] = useState(song.chord_chart ?? '');
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
   const supabase = createClient();
   const isSpotifyLinked = Boolean(song.spotify_url);
+
+  const spotifyInitialQuery = [song.name, song.artist].filter(Boolean).join(' ');
 
   const manualFormFields: FormField[] = useMemo(
     () => [
@@ -65,25 +84,30 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
     [song]
   );
 
-  async function handleSuccess(data: FieldValues) {
+  function handleTabChange(_: React.SyntheticEvent, newMode: Mode) {
+    setMode(newMode);
+    setSelectedTrack(null);
+    setErrorMessage('');
+  }
+
+  async function handleManualSuccess(data: FieldValues) {
     setErrorMessage('');
 
-    const updateData: Record<string, unknown> = {
-      chord_chart: data.chord_chart || null,
-    };
-
-    if (!isSpotifyLinked) {
-      const duration = data.duration ? parseDurationToMs(data.duration) : null;
-      if (data.duration && duration === null) {
-        setErrorMessage('Invalid duration format. Use m:ss (e.g. 3:45).');
-        return;
-      }
-      updateData.name = data.name;
-      updateData.artist = data.artist || null;
-      updateData.duration = duration;
+    const duration = data.duration ? parseDurationToMs(data.duration) : null;
+    if (data.duration && duration === null) {
+      setErrorMessage('Invalid duration format. Use m:ss (e.g. 3:45).');
+      return;
     }
 
-    const { error } = await supabase.from('songs').update(updateData).eq('id', song.id);
+    const { error } = await supabase
+      .from('songs')
+      .update({
+        name: data.name,
+        artist: data.artist || null,
+        duration,
+        chord_chart: data.chord_chart || null,
+      })
+      .eq('id', song.id);
 
     if (error) {
       setErrorMessage(error.message);
@@ -92,6 +116,44 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
     }
   }
 
+  async function handleSpotifyLink() {
+    if (!selectedTrack) return;
+    setIsSubmitting(true);
+    setErrorMessage('');
+
+    const { error } = await supabase
+      .from('songs')
+      .update({
+        name: selectedTrack.name,
+        artist: selectedTrack.artists.map((a) => a.name).join(', '),
+        duration: selectedTrack.duration_ms,
+        spotify_url: selectedTrack.external_urls.spotify,
+        chord_chart: chordChart || null,
+      })
+      .eq('id', song.id);
+
+    setIsSubmitting(false);
+    if (error) {
+      setErrorMessage(error.message);
+    } else {
+      onSuccess?.();
+    }
+  }
+
+  async function handleSpotifyOnlySuccess(data: FieldValues) {
+    setErrorMessage('');
+    const { error } = await supabase
+      .from('songs')
+      .update({ chord_chart: data.chord_chart || null })
+      .eq('id', song.id);
+    if (error) {
+      setErrorMessage(error.message);
+    } else {
+      onSuccess?.();
+    }
+  }
+
+  // Already linked to Spotify: show read-only info + chord chart editor
   if (isSpotifyLinked) {
     return (
       <>
@@ -128,7 +190,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
         </Box>
         <Divider className="mb-4" />
         <Form
-          onSuccess={handleSuccess}
+          onSuccess={handleSpotifyOnlySuccess}
           formFields={[chordChartField]}
           defaultValues={{ chord_chart: song.chord_chart ?? '' }}
           errorMessage={errorMessage}
@@ -138,13 +200,77 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
     );
   }
 
+  // Not linked to Spotify: show tabs
   return (
-    <Form
-      onSuccess={handleSuccess}
-      formFields={manualFormFields}
-      defaultValues={defaultValues}
-      errorMessage={errorMessage}
-      saveButtonLabel="Save Changes"
-    />
+    <>
+      <Tabs value={mode} onChange={handleTabChange} className="mb-4">
+        <Tab icon={<SearchIcon fontSize="small" />} iconPosition="start" label="Search Spotify" value="spotify" />
+        <Tab label="Manual Entry" value="manual" />
+      </Tabs>
+
+      {mode === 'spotify' && (
+        <>
+          {!selectedTrack ? (
+            <SpotifyTrackSearch onSelect={setSelectedTrack} initialQuery={spotifyInitialQuery} />
+          ) : (
+            <>
+              <Box className="mb-4" sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                  Selected song
+                </Typography>
+                <Typography variant="h6" component="p">
+                  {selectedTrack.name}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {selectedTrack.artists.map((a) => a.name).join(', ')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {formatMsToDuration(selectedTrack.duration_ms)}
+                </Typography>
+              </Box>
+              <Divider className="mb-4" />
+              <TextField
+                label="Chord Chart"
+                value={chordChart}
+                onChange={(e) => setChordChart(e.target.value)}
+                fullWidth
+                multiline
+                rows={10}
+                className="mb-4"
+                inputProps={{ style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } }}
+              />
+              {errorMessage && (
+                <Alert severity="error" className="mb-4">
+                  {errorMessage}
+                </Alert>
+              )}
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Button variant="outlined" onClick={() => setSelectedTrack(null)}>
+                  Search Again
+                </Button>
+                <LoadingButton
+                  variant="contained"
+                  loading={isSubmitting}
+                  startIcon={<SaveIcon />}
+                  onClick={handleSpotifyLink}
+                >
+                  Link to Spotify
+                </LoadingButton>
+              </Box>
+            </>
+          )}
+        </>
+      )}
+
+      {mode === 'manual' && (
+        <Form
+          onSuccess={handleManualSuccess}
+          formFields={manualFormFields}
+          defaultValues={defaultValues}
+          errorMessage={errorMessage}
+          saveButtonLabel="Save Changes"
+        />
+      )}
+    </>
   );
 }

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import SpotifyBadge from '@/components/SpotifyBadge';
+import SpotifyBadge, { SpotifyIcon } from '@/components/SpotifyBadge';
 import SpotifyTrackSearch, { SpotifyTrack } from '@/components/SpotifyTrackSearch';
 import { Tables } from '@/types/supabase';
 import { createClient } from '@/utils/supabase/client';
-import { formatMsToDuration, parseDurationToMs } from '@/utils/songs';
+import { cleanSpotifyTrackName, formatMsToDuration, parseDurationToMs } from '@/utils/songs';
 import SaveIcon from '@mui/icons-material/Save';
-import SearchIcon from '@mui/icons-material/Search';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -26,6 +25,7 @@ interface EditSongFormProps {
 }
 
 type Mode = 'spotify' | 'manual';
+type LinkedAction = null | 're-search' | 'confirm-unlink';
 
 const chordChartField: FormField = {
   fieldType: 'textarea',
@@ -38,6 +38,7 @@ const chordChartField: FormField = {
 
 export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormProps>) {
   const [mode, setMode] = useState<Mode>('manual');
+  const [linkedAction, setLinkedAction] = useState<LinkedAction>(null);
   const [selectedTrack, setSelectedTrack] = useState<SpotifyTrack | null>(null);
   const [chordChart, setChordChart] = useState(song.chord_chart ?? '');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -124,7 +125,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
     const { error } = await supabase
       .from('songs')
       .update({
-        name: selectedTrack.name,
+        name: cleanSpotifyTrackName(selectedTrack.name),
         artist: selectedTrack.artists.map((a) => a.name).join(', '),
         duration: selectedTrack.duration_ms,
         spotify_url: selectedTrack.external_urls.spotify,
@@ -153,8 +154,117 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
     }
   }
 
-  // Already linked to Spotify: show read-only info + chord chart editor
+  async function handleUnlink() {
+    setIsSubmitting(true);
+    setErrorMessage('');
+    const { error } = await supabase
+      .from('songs')
+      .update({ spotify_url: null })
+      .eq('id', song.id);
+    setIsSubmitting(false);
+    if (error) {
+      setErrorMessage(error.message);
+    } else {
+      onSuccess?.();
+    }
+  }
+
+  // Already linked to Spotify
   if (isSpotifyLinked) {
+    // Unlink confirmation
+    if (linkedAction === 'confirm-unlink') {
+      return (
+        <>
+          <Alert severity="warning" className="mb-4">
+            Switching to manual entry will remove the Spotify link for this song. You will be able
+            to edit the name, artist, and duration freely, but the song will no longer be linked to
+            Spotify.
+          </Alert>
+          {errorMessage && (
+            <Alert severity="error" className="mb-4">
+              {errorMessage}
+            </Alert>
+          )}
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button variant="outlined" onClick={() => setLinkedAction(null)}>
+              Cancel
+            </Button>
+            <LoadingButton
+              variant="contained"
+              color="warning"
+              loading={isSubmitting}
+              onClick={handleUnlink}
+            >
+              Confirm — Switch to Manual
+            </LoadingButton>
+          </Box>
+        </>
+      );
+    }
+
+    // Re-search Spotify
+    if (linkedAction === 're-search') {
+      return (
+        <>
+          {!selectedTrack ? (
+            <>
+              <SpotifyTrackSearch onSelect={setSelectedTrack} initialQuery={spotifyInitialQuery} />
+              <Button variant="outlined" size="small" onClick={() => setLinkedAction(null)}>
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <>
+              <Box className="mb-4" sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                  Selected song
+                </Typography>
+                <Typography variant="h6" component="p">
+                  {cleanSpotifyTrackName(selectedTrack.name)}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {selectedTrack.artists.map((a) => a.name).join(', ')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {formatMsToDuration(selectedTrack.duration_ms)}
+                </Typography>
+              </Box>
+              <Divider className="mb-4" />
+              <TextField
+                label="Chord Chart"
+                value={chordChart}
+                onChange={(e) => setChordChart(e.target.value)}
+                fullWidth
+                multiline
+                rows={10}
+                className="mb-4"
+                inputProps={{ style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } }}
+              />
+              {errorMessage && (
+                <Alert severity="error" className="mb-4">
+                  {errorMessage}
+                </Alert>
+              )}
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Button variant="outlined" onClick={() => setSelectedTrack(null)}>
+                  Search Again
+                </Button>
+                <LoadingButton
+                  variant="contained"
+                  loading={isSubmitting}
+                  startIcon={<SaveIcon />}
+                  onClick={handleSpotifyLink}
+                >
+                  Update Spotify Link
+                </LoadingButton>
+              </Box>
+            </>
+          )}
+        </>
+      );
+    }
+
+    // Default: show linked info + chord chart
     return (
       <>
         <Box
@@ -187,6 +297,15 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
               {formatMsToDuration(song.duration)}
             </Typography>
           )}
+          <Box sx={{ display: 'flex', gap: 1, mt: 1, pt: 1.5, borderTop: '1px solid rgba(29,185,84,0.25)' }}>
+            <Button size="small" variant="outlined" onClick={() => setLinkedAction('re-search')}
+              sx={{ borderColor: '#1DB954', color: '#1DB954', '&:hover': { borderColor: '#17a349', color: '#17a349' } }}>
+              Change Spotify Link
+            </Button>
+            <Button size="small" color="inherit" onClick={() => setLinkedAction('confirm-unlink')}>
+              Switch to Manual
+            </Button>
+          </Box>
         </Box>
         <Divider className="mb-4" />
         <Form
@@ -204,7 +323,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
   return (
     <>
       <Tabs value={mode} onChange={handleTabChange} className="mb-4">
-        <Tab icon={<SearchIcon fontSize="small" />} iconPosition="start" label="Search Spotify" value="spotify" />
+        <Tab icon={<SpotifyIcon size={16} />} iconPosition="start" label="Search Spotify" value="spotify" />
         <Tab label="Manual Entry" value="manual" />
       </Tabs>
 
@@ -219,7 +338,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
                   Selected song
                 </Typography>
                 <Typography variant="h6" component="p">
-                  {selectedTrack.name}
+                  {cleanSpotifyTrackName(selectedTrack.name)}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   {selectedTrack.artists.map((a) => a.name).join(', ')}

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -1,6 +1,10 @@
+import SpotifyBadge from '@/components/SpotifyBadge';
 import { Tables } from '@/types/supabase';
 import { createClient } from '@/utils/supabase/client';
 import { formatMsToDuration, parseDurationToMs } from '@/utils/songs';
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
 import { useMemo, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 import Form, { FormField } from '../design/Form';
@@ -10,11 +14,21 @@ interface EditSongFormProps {
   onSuccess?: () => void;
 }
 
+const chordChartField: FormField = {
+  fieldType: 'textarea',
+  name: 'chord_chart',
+  label: 'Chord Chart',
+  fullWidth: true,
+  rows: 10,
+  inputProps: { style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } },
+};
+
 export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormProps>) {
   const [errorMessage, setErrorMessage] = useState<string>();
   const supabase = createClient();
+  const isSpotifyLinked = Boolean(song.spotify_url);
 
-  const formFields: FormField[] = useMemo(
+  const manualFormFields: FormField[] = useMemo(
     () => [
       {
         fieldType: 'text' as FormField['fieldType'],
@@ -36,14 +50,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
         placeholder: 'e.g. 3:45',
         fullWidth: true,
       },
-      {
-        fieldType: 'textarea' as FormField['fieldType'],
-        name: 'chord_chart',
-        label: 'Chord Chart',
-        fullWidth: true,
-        rows: 10,
-        inputProps: { style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } },
-      },
+      chordChartField,
     ],
     []
   );
@@ -61,21 +68,22 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
   async function handleSuccess(data: FieldValues) {
     setErrorMessage('');
 
-    const duration = data.duration ? parseDurationToMs(data.duration) : null;
-    if (data.duration && duration === null) {
-      setErrorMessage('Invalid duration format. Use m:ss (e.g. 3:45).');
-      return;
+    const updateData: Record<string, unknown> = {
+      chord_chart: data.chord_chart || null,
+    };
+
+    if (!isSpotifyLinked) {
+      const duration = data.duration ? parseDurationToMs(data.duration) : null;
+      if (data.duration && duration === null) {
+        setErrorMessage('Invalid duration format. Use m:ss (e.g. 3:45).');
+        return;
+      }
+      updateData.name = data.name;
+      updateData.artist = data.artist || null;
+      updateData.duration = duration;
     }
 
-    const { error } = await supabase
-      .from('songs')
-      .update({
-        name: data.name,
-        artist: data.artist || null,
-        duration,
-        chord_chart: data.chord_chart || null,
-      })
-      .eq('id', song.id);
+    const { error } = await supabase.from('songs').update(updateData).eq('id', song.id);
 
     if (error) {
       setErrorMessage(error.message);
@@ -84,10 +92,56 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
     }
   }
 
+  if (isSpotifyLinked) {
+    return (
+      <>
+        <Box
+          sx={{
+            mb: 3,
+            p: 2,
+            border: '1px solid #1DB954',
+            borderRadius: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 0.5,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+            <SpotifyBadge spotifyUrl={song.spotify_url!} />
+            <Typography variant="caption" color="text.secondary">
+              Name, artist, and duration are managed by Spotify
+            </Typography>
+          </Box>
+          <Typography variant="h6" component="p" sx={{ lineHeight: 1.3 }}>
+            {song.name}
+          </Typography>
+          {song.artist && (
+            <Typography variant="body2" color="text.secondary">
+              {song.artist}
+            </Typography>
+          )}
+          {song.duration && (
+            <Typography variant="body2" color="text.secondary">
+              {formatMsToDuration(song.duration)}
+            </Typography>
+          )}
+        </Box>
+        <Divider className="mb-4" />
+        <Form
+          onSuccess={handleSuccess}
+          formFields={[chordChartField]}
+          defaultValues={{ chord_chart: song.chord_chart ?? '' }}
+          errorMessage={errorMessage}
+          saveButtonLabel="Save Changes"
+        />
+      </>
+    );
+  }
+
   return (
     <Form
       onSuccess={handleSuccess}
-      formFields={formFields}
+      formFields={manualFormFields}
       defaultValues={defaultValues}
       errorMessage={errorMessage}
       saveButtonLabel="Save Changes"

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -1,5 +1,6 @@
 import { Tables } from '@/types/supabase';
 import { createClient } from '@/utils/supabase/client';
+import { formatMsToDuration, parseDurationToMs } from '@/utils/songs';
 import { useMemo, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 import Form, { FormField } from '../design/Form';
@@ -7,21 +8,6 @@ import Form, { FormField } from '../design/Form';
 interface EditSongFormProps {
   song: Tables<'songs'>;
   onSuccess?: () => void;
-}
-
-function parseDurationToMs(value: string): number | null {
-  const match = value.trim().match(/^(\d+):([0-5]\d)$/);
-  if (!match) return null;
-  const minutes = parseInt(match[1], 10);
-  const seconds = parseInt(match[2], 10);
-  return (minutes * 60 + seconds) * 1000;
-}
-
-function formatMsToDuration(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
 export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormProps>) {

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -169,7 +169,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
           }}
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
-            <SpotifyBadge spotifyUrl={song.spotify_url!} />
+            <SpotifyBadge spotifyUrl={song.spotify_url!} size={24} />
             <Typography variant="caption" color="text.secondary">
               Name, artist, and duration are managed by Spotify
             </Typography>

--- a/components/setlistEditor/helpers.ts
+++ b/components/setlistEditor/helpers.ts
@@ -55,6 +55,7 @@ export function adaptSetlist(setlist: SetlistComposite, songs: Tables<'songs'>[]
         name: 'Not Found',
         artist: 'Not Found',
         created_at: 'Not Found',
+        spotify_url: null,
       };
     } else {
       usedSongIds.push(song.id);

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,14 @@
 const nextConfig = {
   // set to false due to compatibility issues with react-beautiful-dnd
   reactStrictMode: false,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'i.scdn.co',
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/supabase/migrations/20240116000000_add_spotify_url.sql
+++ b/supabase/migrations/20240116000000_add_spotify_url.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS spotify_url text;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -330,6 +330,7 @@ export type Database = {
           duration: number | null
           id: number
           name: string | null
+          spotify_url: string | null
         }
         Insert: {
           artist?: string | null
@@ -339,6 +340,7 @@ export type Database = {
           duration?: number | null
           id?: number
           name?: string | null
+          spotify_url?: string | null
         }
         Update: {
           artist?: string | null
@@ -348,6 +350,7 @@ export type Database = {
           duration?: number | null
           id?: number
           name?: string | null
+          spotify_url?: string | null
         }
         Relationships: [
           {

--- a/utils/songs.ts
+++ b/utils/songs.ts
@@ -1,0 +1,14 @@
+export function parseDurationToMs(value: string): number | null {
+  const match = value.trim().match(/^(\d+):([0-5]\d)$/);
+  if (!match) return null;
+  const minutes = parseInt(match[1], 10);
+  const seconds = parseInt(match[2], 10);
+  return (minutes * 60 + seconds) * 1000;
+}
+
+export function formatMsToDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}

--- a/utils/songs.ts
+++ b/utils/songs.ts
@@ -1,3 +1,8 @@
+// Strips Spotify remaster suffixes, e.g. " - 2022 Remaster", " - 2019 Remastered Version"
+export function cleanSpotifyTrackName(name: string): string {
+  return name.replace(/ - \(?\d{4} Remaster(?:ed)?(?:\s+\w+)*\)?$/i, '').trim();
+}
+
 export function parseDurationToMs(value: string): number | null {
   const match = value.trim().match(/^(\d+):([0-5]\d)$/);
   if (!match) return null;


### PR DESCRIPTION
Users can search Spotify directly from the Add Song modal and pick a
track to pre-populate name, artist, and duration. The Spotify song URL
is saved alongside the song data. Manual entry remains fully available.

- New server-side /api/spotify/search route using Client Credentials flow
- SpotifyTrackSearch component with album art thumbnails and results list
- AddSongForm updated to embed search, show selected track chip, and
  save spotify_url on insert
- Migration adds spotify_url column to songs table
- Shared utils/songs.ts extracts duration helpers used by both forms
- next.config.js allows Spotify CDN images (i.scdn.co)
- .env.local.example documents NEXT_PUBLIC_SPOTIFY_API_KEY and
  SPOTIFY_CLIENT_SECRET

https://claude.ai/code/session_01McAoTRk4zJcJw9bM9CmgTK