### PR TITLE
Add copyright compliance: ToS, DMCA policy, and content rights notices

### DIFF
--- a/app/dmca/page.tsx
+++ b/app/dmca/page.tsx
@@ -1,0 +1,124 @@
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import Link from '@mui/material/Link';
+
+export const metadata = {
+  title: 'DMCA Policy | Band Manager',
+};
+
+export default function DmcaPage() {
+  return (
+    <Box sx={{ maxWidth: 800, mx: 'auto', py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        DMCA Policy
+      </Typography>
+      <Typography variant="caption" color="text.secondary" display="block" gutterBottom>
+        Last updated: May 2025
+      </Typography>
+
+      <Divider sx={{ my: 3 }} />
+
+      <Typography variant="body1" paragraph>
+        Band Manager respects intellectual property rights and complies with the Digital Millennium
+        Copyright Act (DMCA), 17 U.S.C. § 512. If you believe that content stored within our
+        application infringes your copyright, you may submit a takedown notice as described below.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        How to Submit a Takedown Notice
+      </Typography>
+      <Typography variant="body1" paragraph>
+        To submit a DMCA takedown notice, please provide all of the following in writing:
+      </Typography>
+      <Box component="ol" sx={{ pl: 4, mb: 2 }}>
+        <Typography component="li" variant="body1" gutterBottom>
+          <strong>Identification of the copyrighted work</strong> — A description of the
+          copyrighted work you claim has been infringed, including any registration number if
+          applicable.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          <strong>Identification of the infringing material</strong> — Sufficient information to
+          allow us to locate the material within our application (e.g., the song name, band name,
+          and a description of the content).
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          <strong>Your contact information</strong> — Your name, address, telephone number, and
+          email address.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          <strong>Good faith statement</strong> — A statement that you have a good faith belief
+          that the use of the material is not authorized by the copyright owner, its agent, or
+          the law.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          <strong>Accuracy statement</strong> — A statement, under penalty of perjury, that the
+          information in your notice is accurate and that you are the copyright owner or authorized
+          to act on the copyright owner&apos;s behalf.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          <strong>Signature</strong> — Your physical or electronic signature.
+        </Typography>
+      </Box>
+
+      <Typography variant="h6" gutterBottom>
+        Where to Send Notices
+      </Typography>
+      <Typography variant="body1" paragraph>
+        Send completed takedown notices to our designated DMCA agent via the contact form at{' '}
+        <Link href="https://joshglazer.com" target="_blank" rel="noreferrer" underline="hover">
+          joshglazer.com
+        </Link>
+        . Please include &quot;DMCA Takedown Notice&quot; in the subject line.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        Our Response
+      </Typography>
+      <Typography variant="body1" paragraph>
+        Upon receipt of a valid takedown notice, we will:
+      </Typography>
+      <Box component="ul" sx={{ pl: 4, mb: 2 }}>
+        <Typography component="li" variant="body1" gutterBottom>
+          Promptly review the notice for completeness.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          Remove or disable access to the allegedly infringing content.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          Notify the user who uploaded the content, where required by law.
+        </Typography>
+      </Box>
+
+      <Typography variant="h6" gutterBottom>
+        Counter-Notices
+      </Typography>
+      <Typography variant="body1" paragraph>
+        If you believe your content was removed in error, you may submit a counter-notice. A valid
+        counter-notice must include your contact information, identification of the removed content,
+        a statement under penalty of perjury that you have a good faith belief the content was
+        removed due to mistake or misidentification, and your consent to jurisdiction of the federal
+        court in your district.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        Repeat Infringers
+      </Typography>
+      <Typography variant="body1" paragraph>
+        In appropriate circumstances, we will terminate the accounts of users who are repeat
+        infringers.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        More Information
+      </Typography>
+      <Typography variant="body1" paragraph>
+        For general questions about acceptable use of content in Band Manager, please review our{' '}
+        <Link href="/tos" underline="hover">
+          Terms of Service
+        </Link>
+        .
+      </Typography>
+    </Box>
+  );
+}

--- a/app/tos/page.tsx
+++ b/app/tos/page.tsx
@@ -1,0 +1,149 @@
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import Link from '@mui/material/Link';
+
+export const metadata = {
+  title: 'Terms of Service | Band Manager',
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <Box sx={{ maxWidth: 800, mx: 'auto', py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Terms of Service
+      </Typography>
+      <Typography variant="caption" color="text.secondary" display="block" gutterBottom>
+        Last updated: May 2025
+      </Typography>
+
+      <Divider sx={{ my: 3 }} />
+
+      <Typography variant="h6" gutterBottom>
+        1. Acceptance of Terms
+      </Typography>
+      <Typography variant="body1" paragraph>
+        By using Band Manager, you agree to these Terms of Service. If you do not agree, please do
+        not use the application.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        2. User-Generated Content
+      </Typography>
+      <Typography variant="body1" paragraph>
+        Band Manager allows you to store notes, lyrics, chord charts, and other content associated
+        with your band&apos;s songs (&quot;User Content&quot;). You are solely responsible for all
+        User Content you upload, enter, or store in the application.
+      </Typography>
+      <Typography variant="body1" paragraph>
+        By submitting User Content, you represent and warrant that:
+      </Typography>
+      <Box component="ul" sx={{ pl: 4, mb: 2 }}>
+        <Typography component="li" variant="body1" gutterBottom>
+          You own the content, or you have the legal right to use and store it.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          Your content does not infringe the copyrights, trademarks, or other intellectual property
+          rights of any third party.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          You have obtained any necessary permissions or licenses from copyright holders before
+          storing copyrighted material.
+        </Typography>
+      </Box>
+      <Typography variant="body1" paragraph>
+        We do not review, verify, or endorse User Content. You bear full responsibility for ensuring
+        your use of any third-party material complies with applicable law.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        3. Copyright and Intellectual Property
+      </Typography>
+      <Typography variant="body1" paragraph>
+        Band Manager respects intellectual property rights. We comply with the Digital Millennium
+        Copyright Act (DMCA) and will respond to valid takedown notices. If you believe content in
+        the application infringes your copyright, please review our{' '}
+        <Link href="/dmca" underline="hover">
+          DMCA Policy
+        </Link>
+        .
+      </Typography>
+      <Typography variant="body1" paragraph>
+        As a general guide:
+      </Typography>
+      <Box component="ul" sx={{ pl: 4, mb: 2 }}>
+        <Typography component="li" variant="body1" gutterBottom>
+          Personal notes and original content you wrote — generally safe to store.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          Chord progressions you worked out yourself — generally safe to store.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          Lyrics, tabs, or transcriptions copied from other sources — may be protected by copyright;
+          ensure you have the right to use them.
+        </Typography>
+      </Box>
+
+      <Typography variant="h6" gutterBottom>
+        4. Privacy of Your Content
+      </Typography>
+      <Typography variant="body1" paragraph>
+        Your band&apos;s content is private and accessible only to members of your band. We do not
+        publish, index, or share your User Content with other users or the public.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        5. Prohibited Uses
+      </Typography>
+      <Typography variant="body1" paragraph>
+        You agree not to use Band Manager to:
+      </Typography>
+      <Box component="ul" sx={{ pl: 4, mb: 2 }}>
+        <Typography component="li" variant="body1" gutterBottom>
+          Store or distribute content that infringes third-party intellectual property rights.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          Violate any applicable law or regulation.
+        </Typography>
+        <Typography component="li" variant="body1" gutterBottom>
+          Attempt to gain unauthorized access to other users&apos; data.
+        </Typography>
+      </Box>
+
+      <Typography variant="h6" gutterBottom>
+        6. Disclaimer of Warranties
+      </Typography>
+      <Typography variant="body1" paragraph>
+        Band Manager is provided &quot;as is&quot; without warranties of any kind. We make no
+        guarantees about uptime, data retention, or fitness for a particular purpose.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        7. Limitation of Liability
+      </Typography>
+      <Typography variant="body1" paragraph>
+        To the maximum extent permitted by law, we are not liable for any indirect, incidental,
+        special, or consequential damages arising from your use of Band Manager.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        8. Changes to These Terms
+      </Typography>
+      <Typography variant="body1" paragraph>
+        We may update these Terms from time to time. Continued use of Band Manager after changes
+        are posted constitutes your acceptance of the revised Terms.
+      </Typography>
+
+      <Typography variant="h6" gutterBottom>
+        9. Contact
+      </Typography>
+      <Typography variant="body1" paragraph>
+        Questions about these Terms? Contact us at{' '}
+        <Link href="https://joshglazer.com" target="_blank" rel="noreferrer" underline="hover">
+          joshglazer.com
+        </Link>
+        .
+      </Typography>
+    </Box>
+  );
+}

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -159,6 +159,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
                 rows={10}
                 className="mb-4"
                 inputProps={{ style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } }}
+                helperText="Only upload content you have the right to use (your own notes, original transcriptions, or content you are licensed to store)."
               />
               {errorMessage && (
                 <Alert severity="error" className="mb-4">

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -62,6 +62,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
         fullWidth: true,
         rows: 10,
         inputProps: { style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } },
+        helperText: 'Only upload content you have the right to use (your own notes, original transcriptions, or content you are licensed to store).',
       },
     ],
     []

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -34,6 +34,7 @@ const sharedBandNotesField: FormField = {
   fullWidth: true,
   rows: 10,
   inputProps: { style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } },
+  helperText: 'Only upload content you have the right to use (your own notes, original transcriptions, or content you are licensed to store).',
 };
 
 export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormProps>) {

--- a/components/forms/SharedBandNotesForm.tsx
+++ b/components/forms/SharedBandNotesForm.tsx
@@ -19,6 +19,7 @@ const formFields: FormField[] = [
     fullWidth: true,
     rows: 15,
     inputProps: { style: { fontFamily: 'monospace', fontSize: '0.95rem', lineHeight: 1.8 } },
+    helperText: 'Only upload content you have the right to use (your own notes, original transcriptions, or content you are licensed to store).',
   },
 ];
 

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -13,10 +13,11 @@ export default function Footer() {
         justifyContent: 'center',
         borderTop: '1px solid',
         borderColor: 'divider',
-        height: 64,
+        minHeight: 64,
+        py: 1,
       }}
     >
-      <div className="w-full flex justify-between items-center px-3">
+      <div className="w-full flex flex-wrap justify-between items-center gap-2 px-3">
         <Typography variant="caption" color="text.secondary">
           A{' '}
           <Link href="https://joshglazer.com" target="_blank" rel="noreferrer" underline="hover" color="inherit" fontWeight={600}>
@@ -24,16 +25,24 @@ export default function Footer() {
           </Link>{' '}
           Project
         </Typography>
-        <Link
-          href="https://github.com/joshglazer/band-manager"
-          target="_blank"
-          rel="noreferrer"
-          underline="hover"
-          color="text.secondary"
-          sx={{ display: 'flex', alignItems: 'center', gap: 0.5, fontSize: '0.75rem', fontWeight: 600 }}
-        >
-          <GitHubIcon sx={{ fontSize: 16 }} /> Source Code
-        </Link>
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+          <Link href="/tos" underline="hover" color="text.secondary" sx={{ fontSize: '0.75rem' }}>
+            Terms of Service
+          </Link>
+          <Link href="/dmca" underline="hover" color="text.secondary" sx={{ fontSize: '0.75rem' }}>
+            DMCA
+          </Link>
+          <Link
+            href="https://github.com/joshglazer/band-manager"
+            target="_blank"
+            rel="noreferrer"
+            underline="hover"
+            color="text.secondary"
+            sx={{ display: 'flex', alignItems: 'center', gap: 0.5, fontSize: '0.75rem', fontWeight: 600 }}
+          >
+            <GitHubIcon sx={{ fontSize: 16 }} /> Source Code
+          </Link>
+        </Box>
       </div>
     </Box>
   );


### PR DESCRIPTION
## Summary

- **Terms of Service page** (`/tos`) — users agree they own or are licensed to use any content they upload; references DMCA policy
- **DMCA policy page** (`/dmca`) — standard DMCA safe harbor takedown procedure with required notice elements and counter-notice process
- **Footer links** — ToS and DMCA links added alongside the existing Source Code link
- **Content rights helper text** — added to all three Shared Band Notes form fields (Add Song, Edit Song, Shared Band Notes form) reminding users to only upload content they have the right to use

## Test plan

- [ ] Visit `/tos` and `/dmca` pages and confirm they render correctly
- [ ] Confirm footer shows "Terms of Service" and "DMCA" links that navigate to the correct pages
- [ ] Open Add Song form and confirm helper text appears below the Shared Band Notes textarea
- [ ] Open Edit Song form and confirm helper text appears below the Shared Band Notes textarea
- [ ] Open the Shared Band Notes edit page for a song and confirm helper text appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)