### PR TITLE
Add audio file upload support for songs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json
 
 # local env files
 .env*.local

--- a/app/band/[bandId]/practice/page.tsx
+++ b/app/band/[bandId]/practice/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import AudioPlayBadge from '@/components/AudioPlayBadge';
 import SongLinkIcon from '@/components/SongLinkIcon';
 import SpotifyBadge from '@/components/SpotifyBadge';
 import Loading from '@/components/design/Loading';
@@ -418,6 +419,8 @@ export default function BandPracticePage({ params }: Readonly<BandRouteProps>) {
                       <SongLinkIcon url={song.song_link} />
                     ) : song.spotify_url ? (
                       <SpotifyBadge spotifyUrl={song.spotify_url} />
+                    ) : song.audio_url ? (
+                      <AudioPlayBadge audioUrl={song.audio_url} />
                     ) : null}
                     {song.shared_band_notes && (
                       <SharedBandNotesViewModal songName={song.name} sharedBandNotes={song.shared_band_notes} iconOnly />

--- a/app/band/[bandId]/songs/page.tsx
+++ b/app/band/[bandId]/songs/page.tsx
@@ -6,6 +6,7 @@ import Table, { TableProps, TablePropsDataType, TableRow } from '@/components/de
 import EditSongForm from '@/components/forms/EditSongForm';
 import SongCommentForm from '@/components/forms/SongCommentForm';
 import AddSongModal from '@/components/modals/AddSongModal';
+import AudioPlayBadge from '@/components/AudioPlayBadge';
 import SongLinkIcon from '@/components/SongLinkIcon';
 import SpotifyBadge from '@/components/SpotifyBadge';
 import useSongs, { SongsComposite } from '@/hooks/useSongs';
@@ -136,12 +137,11 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
   function formatLinkIcon(_value: TablePropsDataType | null, row: TableRow) {
     const songLink = row.song_link as string | null;
     const spotifyUrl = row.spotify_url as string | null;
-    const url = songLink || spotifyUrl;
-    if (!url) return '';
-    if (!songLink && spotifyUrl) {
-      return <SpotifyBadge spotifyUrl={spotifyUrl} />;
-    }
-    return <SongLinkIcon url={url} />;
+    const audioUrl = row.audio_url as string | null;
+    if (songLink) return <SongLinkIcon url={songLink} />;
+    if (spotifyUrl) return <SpotifyBadge spotifyUrl={spotifyUrl} />;
+    if (audioUrl) return <AudioPlayBadge audioUrl={audioUrl} />;
+    return '';
   }
 
   function formatActions(_value: TablePropsDataType | null, row: TableRow) {
@@ -164,6 +164,7 @@ export default function BandSongsPage({ params }: Readonly<BandRouteProps>) {
       duration: song.duration,
       song_link: song.song_link,
       spotify_url: song.spotify_url,
+      audio_url: song.audio_url,
     }));
 
     const q = searchQuery.toLowerCase();

--- a/components/AudioFileInput.tsx
+++ b/components/AudioFileInput.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import AudiotrackIcon from '@mui/icons-material/Audiotrack';
+import ClearIcon from '@mui/icons-material/Clear';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import { useEffect, useRef, useState } from 'react';
+
+interface AudioFileInputProps {
+  existingUrl?: string | null;
+  onFileSelect: (file: File | null) => void;
+  onRemoveExisting?: () => void;
+}
+
+export default function AudioFileInput({
+  existingUrl,
+  onFileSelect,
+  onRemoveExisting,
+}: Readonly<AudioFileInputProps>) {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!selectedFile) {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(selectedFile);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [selectedFile]);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0] ?? null;
+    setSelectedFile(file);
+    onFileSelect(file);
+  }
+
+  function handleClearSelected() {
+    setSelectedFile(null);
+    onFileSelect(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <Box className="mb-4">
+      <Typography variant="subtitle2" gutterBottom>
+        Audio File (optional)
+      </Typography>
+
+      {existingUrl && !selectedFile && (
+        <Box sx={{ mb: 1 }}>
+          <audio controls src={existingUrl} style={{ width: '100%', marginBottom: 8 }} />
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<AudiotrackIcon />}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              Replace Audio
+            </Button>
+            {onRemoveExisting && (
+              <Button
+                size="small"
+                color="error"
+                startIcon={<ClearIcon />}
+                onClick={onRemoveExisting}
+              >
+                Remove Audio
+              </Button>
+            )}
+          </Box>
+        </Box>
+      )}
+
+      {selectedFile && previewUrl && (
+        <Box sx={{ mb: 1 }}>
+          <audio controls src={previewUrl} style={{ width: '100%', marginBottom: 4 }} />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <AudiotrackIcon fontSize="small" color="action" />
+            <Typography variant="body2" sx={{ flex: 1 }} noWrap>
+              {selectedFile.name}
+            </Typography>
+            <IconButton size="small" onClick={handleClearSelected} aria-label="clear selected file">
+              <ClearIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        </Box>
+      )}
+
+      {!existingUrl && !selectedFile && (
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<AudiotrackIcon />}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          Upload Audio
+        </Button>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="audio/*"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
+    </Box>
+  );
+}

--- a/components/AudioPlayBadge.tsx
+++ b/components/AudioPlayBadge.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import PlayCircleIcon from '@mui/icons-material/PlayCircle';
+import IconButton from '@mui/material/IconButton';
+import Popover from '@mui/material/Popover';
+import Tooltip from '@mui/material/Tooltip';
+import { useState } from 'react';
+
+interface AudioPlayBadgeProps {
+  audioUrl: string;
+  size?: number;
+}
+
+export default function AudioPlayBadge({ audioUrl, size = 20 }: Readonly<AudioPlayBadgeProps>) {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  return (
+    <>
+      <Tooltip title="Play audio">
+        <IconButton
+          size="small"
+          onClick={(e) => setAnchorEl(e.currentTarget)}
+          sx={{ p: 0, flexShrink: 0, color: 'primary.main' }}
+          aria-label="Play audio"
+        >
+          <PlayCircleIcon sx={{ fontSize: size }} />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      >
+        <audio
+          controls
+          autoPlay
+          src={audioUrl}
+          style={{ display: 'block', width: 280, padding: '8px' }}
+        />
+      </Popover>
+    </>
+  );
+}

--- a/components/SongReferenceInput.tsx
+++ b/components/SongReferenceInput.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import AudioFileInput from '@/components/AudioFileInput';
+import AudiotrackIcon from '@mui/icons-material/Audiotrack';
+import LinkIcon from '@mui/icons-material/Link';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+
+export type SongRefType = 'link' | 'audio';
+
+interface SongReferenceInputProps {
+  type: SongRefType;
+  linkUrl: string;
+  existingAudioUrl?: string | null;
+  onTypeChange: (type: SongRefType) => void;
+  onLinkChange: (url: string) => void;
+  onAudioFileSelect: (file: File | null) => void;
+  onRemoveExistingAudio: () => void;
+}
+
+export default function SongReferenceInput({
+  type,
+  linkUrl,
+  existingAudioUrl,
+  onTypeChange,
+  onLinkChange,
+  onAudioFileSelect,
+  onRemoveExistingAudio,
+}: Readonly<SongReferenceInputProps>) {
+  function handleTypeChange(_: React.MouseEvent, newType: SongRefType | null) {
+    if (!newType || newType === type) return;
+    onTypeChange(newType);
+  }
+
+  return (
+    <Box className="mb-4">
+      <ToggleButtonGroup
+        value={type}
+        exclusive
+        onChange={handleTypeChange}
+        size="small"
+        sx={{ mb: 1.5 }}
+      >
+        <ToggleButton value="link">
+          <LinkIcon fontSize="small" sx={{ mr: 0.5 }} />
+          Link (URL)
+        </ToggleButton>
+        <ToggleButton value="audio">
+          <AudiotrackIcon fontSize="small" sx={{ mr: 0.5 }} />
+          Upload Audio
+        </ToggleButton>
+      </ToggleButtonGroup>
+
+      {type === 'link' && (
+        <TextField
+          label="Link (URL)"
+          value={linkUrl}
+          onChange={(e) => onLinkChange(e.target.value)}
+          placeholder="e.g. https://soundcloud.com/..."
+          fullWidth
+        />
+      )}
+
+      {type === 'audio' && (
+        <AudioFileInput
+          existingUrl={existingAudioUrl}
+          onFileSelect={onAudioFileSelect}
+          onRemoveExisting={onRemoveExistingAudio}
+        />
+      )}
+    </Box>
+  );
+}

--- a/components/design/Form.tsx
+++ b/components/design/Form.tsx
@@ -3,7 +3,7 @@
 import SaveIcon from '@mui/icons-material/Save';
 import LoadingButton from '@mui/lab/LoadingButton';
 import Alert from '@mui/material/Alert';
-import { useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   FieldValues,
   FormContainer,
@@ -32,6 +32,7 @@ interface FormProps {
   saveButtonLabel?: string;
   saveButtonDisplay?: boolean;
   saveButtonIcon?: JSX.Element;
+  extraContent?: React.ReactNode;
 }
 
 export default function Form({
@@ -42,6 +43,7 @@ export default function Form({
   saveButtonLabel = 'Save',
   saveButtonDisplay = true,
   saveButtonIcon = <SaveIcon />,
+  extraContent,
 }: Readonly<FormProps>) {
   const [isFormProcessing, setIsFormProcessing] = useState(false);
 
@@ -108,6 +110,7 @@ export default function Form({
 
         return field;
       })}
+      {extraContent}
       {errorMessage && (
         <Alert severity="error" className="mb-4">
           {errorMessage}

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import AudioFileInput from '@/components/AudioFileInput';
 import { SpotifyIcon } from '@/components/SpotifyBadge';
 import SpotifyTrackSearch, { SpotifyTrack } from '@/components/SpotifyTrackSearch';
 import { createClient } from '@/utils/supabase/client';
@@ -14,7 +15,7 @@ import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 import Form, { FormField } from '../design/Form';
 
@@ -25,12 +26,28 @@ interface AddSongFormProps {
 
 type Mode = 'spotify' | 'manual';
 
+async function uploadSongAudio(
+  supabase: ReturnType<typeof createClient>,
+  file: File,
+  bandId: number
+): Promise<string> {
+  const ext = file.name.split('.').pop() ?? 'audio';
+  const path = `${bandId}/${crypto.randomUUID()}.${ext}`;
+  const { error } = await supabase.storage.from('song-audio').upload(path, file, {
+    contentType: file.type,
+  });
+  if (error) throw new Error(error.message);
+  const { data } = supabase.storage.from('song-audio').getPublicUrl(path);
+  return data.publicUrl;
+}
+
 export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormProps>) {
   const [mode, setMode] = useState<Mode>('spotify');
   const [selectedTrack, setSelectedTrack] = useState<SpotifyTrack | null>(null);
   const [sharedBandNotes, setSharedBandNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
+  const audioFileRef = useRef<File | null>(null);
   const supabase = createClient();
 
   const manualFormFields: FormField[] = useMemo(
@@ -106,12 +123,23 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
       return;
     }
 
+    let audioUrl: string | null = null;
+    if (audioFileRef.current) {
+      try {
+        audioUrl = await uploadSongAudio(supabase, audioFileRef.current, bandId);
+      } catch (err) {
+        setErrorMessage(err instanceof Error ? err.message : 'Failed to upload audio file.');
+        return;
+      }
+    }
+
     const { error } = await supabase.from('songs').insert({
       name: data.name,
       artist: data.artist || null,
       duration,
       shared_band_notes: data.shared_band_notes || null,
       song_link: data.song_link || null,
+      audio_url: audioUrl,
       band_id: bandId,
       spotify_url: null,
     });
@@ -128,6 +156,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
     setSelectedTrack(null);
     setSharedBandNotes('');
     setErrorMessage('');
+    audioFileRef.current = null;
   }
 
   return (
@@ -198,6 +227,11 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
           formFields={manualFormFields}
           errorMessage={errorMessage}
           saveButtonLabel="Add Song"
+          extraContent={
+            <AudioFileInput
+              onFileSelect={(file) => { audioFileRef.current = file; }}
+            />
+          }
         />
       )}
     </>

--- a/components/forms/AddSongForm.tsx
+++ b/components/forms/AddSongForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import AudioFileInput from '@/components/AudioFileInput';
+import SongReferenceInput, { SongRefType } from '@/components/SongReferenceInput';
 import { SpotifyIcon } from '@/components/SpotifyBadge';
 import SpotifyTrackSearch, { SpotifyTrack } from '@/components/SpotifyTrackSearch';
 import { createClient } from '@/utils/supabase/client';
@@ -47,6 +47,8 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
   const [sharedBandNotes, setSharedBandNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [songRefType, setSongRefType] = useState<SongRefType>('link');
+  const [linkUrl, setLinkUrl] = useState('');
   const audioFileRef = useRef<File | null>(null);
   const supabase = createClient();
 
@@ -70,13 +72,6 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
         name: 'duration',
         label: 'Duration (m:ss)',
         placeholder: 'e.g. 3:45',
-        fullWidth: true,
-      },
-      {
-        fieldType: 'text' as FormField['fieldType'],
-        name: 'song_link',
-        label: 'Link (URL)',
-        placeholder: 'e.g. https://soundcloud.com/...',
         fullWidth: true,
       },
       {
@@ -124,7 +119,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
     }
 
     let audioUrl: string | null = null;
-    if (audioFileRef.current) {
+    if (songRefType === 'audio' && audioFileRef.current) {
       try {
         audioUrl = await uploadSongAudio(supabase, audioFileRef.current, bandId);
       } catch (err) {
@@ -138,7 +133,7 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
       artist: data.artist || null,
       duration,
       shared_band_notes: data.shared_band_notes || null,
-      song_link: data.song_link || null,
+      song_link: songRefType === 'link' ? (linkUrl || null) : null,
       audio_url: audioUrl,
       band_id: bandId,
       spotify_url: null,
@@ -156,7 +151,18 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
     setSelectedTrack(null);
     setSharedBandNotes('');
     setErrorMessage('');
+    setSongRefType('link');
+    setLinkUrl('');
     audioFileRef.current = null;
+  }
+
+  function handleRefTypeChange(newType: SongRefType) {
+    setSongRefType(newType);
+    if (newType === 'link') {
+      audioFileRef.current = null;
+    } else {
+      setLinkUrl('');
+    }
   }
 
   return (
@@ -228,8 +234,13 @@ export default function AddSongForm({ bandId, onSuccess }: Readonly<AddSongFormP
           errorMessage={errorMessage}
           saveButtonLabel="Add Song"
           extraContent={
-            <AudioFileInput
-              onFileSelect={(file) => { audioFileRef.current = file; }}
+            <SongReferenceInput
+              type={songRefType}
+              linkUrl={linkUrl}
+              onTypeChange={handleRefTypeChange}
+              onLinkChange={setLinkUrl}
+              onAudioFileSelect={(file) => { audioFileRef.current = file; }}
+              onRemoveExistingAudio={() => { audioFileRef.current = null; }}
             />
           }
         />

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import AudioFileInput from '@/components/AudioFileInput';
 import SpotifyBadge, { SpotifyIcon } from '@/components/SpotifyBadge';
 import SpotifyTrackSearch, { SpotifyTrack } from '@/components/SpotifyTrackSearch';
 import { Tables } from '@/types/supabase';
@@ -15,7 +16,7 @@ import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 import Form, { FormField } from '../design/Form';
 
@@ -45,6 +46,35 @@ const songLinkField: FormField = {
   fullWidth: true,
 };
 
+async function uploadSongAudio(
+  supabase: ReturnType<typeof createClient>,
+  file: File,
+  bandId: number
+): Promise<string> {
+  const ext = file.name.split('.').pop() ?? 'audio';
+  const path = `${bandId}/${crypto.randomUUID()}.${ext}`;
+  const { error } = await supabase.storage.from('song-audio').upload(path, file, {
+    contentType: file.type,
+  });
+  if (error) throw new Error(error.message);
+  const { data } = supabase.storage.from('song-audio').getPublicUrl(path);
+  return data.publicUrl;
+}
+
+async function deleteSongAudio(
+  supabase: ReturnType<typeof createClient>,
+  audioUrl: string
+): Promise<void> {
+  try {
+    const url = new URL(audioUrl);
+    const pathParts = url.pathname.split('/song-audio/');
+    if (pathParts.length < 2) return;
+    await supabase.storage.from('song-audio').remove([pathParts[1]]);
+  } catch {
+    // ignore storage delete errors — the DB update is the source of truth
+  }
+}
+
 export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormProps>) {
   const [mode, setMode] = useState<Mode>('manual');
   const [linkedAction, setLinkedAction] = useState<LinkedAction>(null);
@@ -52,6 +82,8 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
   const [sharedBandNotes, setSharedBandNotes] = useState(song.shared_band_notes ?? '');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [removeAudio, setRemoveAudio] = useState(false);
+  const audioFileRef = useRef<File | null>(null);
   const supabase = createClient();
   const isSpotifyLinked = Boolean(song.spotify_url);
 
@@ -102,6 +134,19 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
     [song]
   );
 
+  async function resolveAudioUrl(): Promise<{ audio_url?: string | null }> {
+    if (removeAudio) {
+      if (song.audio_url) await deleteSongAudio(supabase, song.audio_url);
+      return { audio_url: null };
+    }
+    if (audioFileRef.current) {
+      if (song.audio_url) await deleteSongAudio(supabase, song.audio_url);
+      const url = await uploadSongAudio(supabase, audioFileRef.current, song.band_id);
+      return { audio_url: url };
+    }
+    return {};
+  }
+
   function handleTabChange(_: React.SyntheticEvent, newMode: Mode) {
     setMode(newMode);
     setSelectedTrack(null);
@@ -117,6 +162,14 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
       return;
     }
 
+    let audioUpdate: { audio_url?: string | null } = {};
+    try {
+      audioUpdate = await resolveAudioUrl();
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to upload audio file.');
+      return;
+    }
+
     const { error } = await supabase
       .from('songs')
       .update({
@@ -125,6 +178,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
         duration,
         song_link: data.song_link || null,
         shared_band_notes: data.shared_band_notes || null,
+        ...audioUpdate,
       })
       .eq('id', song.id);
 
@@ -184,6 +238,14 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
       return;
     }
 
+    let audioUpdate: { audio_url?: string | null } = {};
+    try {
+      audioUpdate = await resolveAudioUrl();
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to upload audio file.');
+      return;
+    }
+
     const { error } = await supabase
       .from('songs')
       .update({
@@ -193,6 +255,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
         song_link: data.song_link || null,
         shared_band_notes: data.shared_band_notes || null,
         spotify_url: null,
+        ...audioUpdate,
       })
       .eq('id', song.id);
 
@@ -202,6 +265,20 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
       onSuccess?.();
     }
   }
+
+  const audioInputElement = (
+    <AudioFileInput
+      existingUrl={removeAudio ? null : song.audio_url}
+      onFileSelect={(file) => {
+        audioFileRef.current = file;
+        if (file) setRemoveAudio(false);
+      }}
+      onRemoveExisting={() => {
+        setRemoveAudio(true);
+        audioFileRef.current = null;
+      }}
+    />
+  );
 
   // Already linked to Spotify
   if (isSpotifyLinked) {
@@ -214,6 +291,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
           defaultValues={defaultValues}
           errorMessage={errorMessage}
           saveButtonLabel="Save Changes"
+          extraContent={audioInputElement}
         />
       );
     }
@@ -429,6 +507,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
           defaultValues={defaultValues}
           errorMessage={errorMessage}
           saveButtonLabel="Save Changes"
+          extraContent={audioInputElement}
         />
       )}
     </>

--- a/components/forms/EditSongForm.tsx
+++ b/components/forms/EditSongForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import AudioFileInput from '@/components/AudioFileInput';
+import SongReferenceInput, { SongRefType } from '@/components/SongReferenceInput';
 import SpotifyBadge, { SpotifyIcon } from '@/components/SpotifyBadge';
 import SpotifyTrackSearch, { SpotifyTrack } from '@/components/SpotifyTrackSearch';
 import { Tables } from '@/types/supabase';
@@ -75,6 +75,10 @@ async function deleteSongAudio(
   }
 }
 
+function initSongRefType(song: Tables<'songs'>): SongRefType {
+  return song.audio_url ? 'audio' : 'link';
+}
+
 export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormProps>) {
   const [mode, setMode] = useState<Mode>('manual');
   const [linkedAction, setLinkedAction] = useState<LinkedAction>(null);
@@ -82,6 +86,8 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
   const [sharedBandNotes, setSharedBandNotes] = useState(song.shared_band_notes ?? '');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [songRefType, setSongRefType] = useState<SongRefType>(initSongRefType(song));
+  const [linkUrl, setLinkUrl] = useState(song.song_link ?? '');
   const [removeAudio, setRemoveAudio] = useState(false);
   const audioFileRef = useRef<File | null>(null);
   const supabase = createClient();
@@ -111,13 +117,6 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
         placeholder: 'e.g. 3:45',
         fullWidth: true,
       },
-      {
-        fieldType: 'text' as FormField['fieldType'],
-        name: 'song_link',
-        label: 'Link (URL)',
-        placeholder: 'e.g. https://soundcloud.com/...',
-        fullWidth: true,
-      },
       sharedBandNotesField,
     ],
     []
@@ -128,23 +127,39 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
       name: song.name ?? '',
       artist: song.artist ?? '',
       duration: song.duration ? formatMsToDuration(song.duration) : '',
-      song_link: song.song_link ?? '',
       shared_band_notes: song.shared_band_notes ?? '',
     }),
     [song]
   );
 
-  async function resolveAudioUrl(): Promise<{ audio_url?: string | null }> {
+  function handleRefTypeChange(newType: SongRefType) {
+    setSongRefType(newType);
+    if (newType === 'link') {
+      audioFileRef.current = null;
+      if (song.audio_url) setRemoveAudio(true);
+    } else {
+      setLinkUrl('');
+      setRemoveAudio(false);
+    }
+  }
+
+  async function resolveRefFields(): Promise<{ song_link: string | null; audio_url: string | null } | null> {
+    if (songRefType === 'link') {
+      if (song.audio_url) await deleteSongAudio(supabase, song.audio_url);
+      return { song_link: linkUrl || null, audio_url: null };
+    }
+    // audio type
     if (removeAudio) {
       if (song.audio_url) await deleteSongAudio(supabase, song.audio_url);
-      return { audio_url: null };
+      return { song_link: null, audio_url: null };
     }
     if (audioFileRef.current) {
       if (song.audio_url) await deleteSongAudio(supabase, song.audio_url);
       const url = await uploadSongAudio(supabase, audioFileRef.current, song.band_id);
-      return { audio_url: url };
+      return { song_link: null, audio_url: url };
     }
-    return {};
+    // no change to audio
+    return { song_link: null, audio_url: song.audio_url };
   }
 
   function handleTabChange(_: React.SyntheticEvent, newMode: Mode) {
@@ -162,9 +177,9 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
       return;
     }
 
-    let audioUpdate: { audio_url?: string | null } = {};
+    let refFields: { song_link: string | null; audio_url: string | null } | null = null;
     try {
-      audioUpdate = await resolveAudioUrl();
+      refFields = await resolveRefFields();
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : 'Failed to upload audio file.');
       return;
@@ -176,9 +191,8 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
         name: data.name,
         artist: data.artist || null,
         duration,
-        song_link: data.song_link || null,
         shared_band_notes: data.shared_band_notes || null,
-        ...audioUpdate,
+        ...refFields,
       })
       .eq('id', song.id);
 
@@ -238,9 +252,9 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
       return;
     }
 
-    let audioUpdate: { audio_url?: string | null } = {};
+    let refFields: { song_link: string | null; audio_url: string | null } | null = null;
     try {
-      audioUpdate = await resolveAudioUrl();
+      refFields = await resolveRefFields();
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : 'Failed to upload audio file.');
       return;
@@ -252,10 +266,9 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
         name: data.name,
         artist: data.artist || null,
         duration,
-        song_link: data.song_link || null,
         shared_band_notes: data.shared_band_notes || null,
         spotify_url: null,
-        ...audioUpdate,
+        ...refFields,
       })
       .eq('id', song.id);
 
@@ -266,14 +279,18 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
     }
   }
 
-  const audioInputElement = (
-    <AudioFileInput
-      existingUrl={removeAudio ? null : song.audio_url}
-      onFileSelect={(file) => {
+  const songReferenceInput = (
+    <SongReferenceInput
+      type={songRefType}
+      linkUrl={linkUrl}
+      existingAudioUrl={removeAudio ? null : song.audio_url}
+      onTypeChange={handleRefTypeChange}
+      onLinkChange={setLinkUrl}
+      onAudioFileSelect={(file) => {
         audioFileRef.current = file;
         if (file) setRemoveAudio(false);
       }}
-      onRemoveExisting={() => {
+      onRemoveExistingAudio={() => {
         setRemoveAudio(true);
         audioFileRef.current = null;
       }}
@@ -282,7 +299,6 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
 
   // Already linked to Spotify
   if (isSpotifyLinked) {
-    // Confirmed unlink: show manual form; spotify_url removed only on save
     if (linkedAction === 'manual-edit') {
       return (
         <Form
@@ -291,12 +307,11 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
           defaultValues={defaultValues}
           errorMessage={errorMessage}
           saveButtonLabel="Save Changes"
-          extraContent={audioInputElement}
+          extraContent={songReferenceInput}
         />
       );
     }
 
-    // Unlink confirmation
     if (linkedAction === 'confirm-unlink') {
       return (
         <>
@@ -321,7 +336,6 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
       );
     }
 
-    // Re-search Spotify
     if (linkedAction === 're-search') {
       return (
         <>
@@ -383,7 +397,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
       );
     }
 
-    // Default: show linked info + chord chart
+    // Default: show linked info + link field + notes
     return (
       <>
         <Box
@@ -507,7 +521,7 @@ export default function EditSongForm({ song, onSuccess }: Readonly<EditSongFormP
           defaultValues={defaultValues}
           errorMessage={errorMessage}
           saveButtonLabel="Save Changes"
-          extraContent={audioInputElement}
+          extraContent={songReferenceInput}
         />
       )}
     </>

--- a/components/setlistEditor/helpers.ts
+++ b/components/setlistEditor/helpers.ts
@@ -50,6 +50,7 @@ export function adaptSetlist(setlist: SetlistComposite, songs: Tables<'songs'>[]
       song = {
         band_id,
         shared_band_notes: null,
+        audio_url: null,
         duration: 0,
         id: -1,
         name: 'Not Found',

--- a/supabase/migrations/20240119000000_add_audio_upload.sql
+++ b/supabase/migrations/20240119000000_add_audio_upload.sql
@@ -1,0 +1,34 @@
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS audio_url text;
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('song-audio', 'song-audio', true)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "Band members can upload song audio"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'song-audio' AND
+  is_band_member((split_part(name, '/', 1))::integer)
+);
+
+CREATE POLICY "Band members can update song audio"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'song-audio' AND
+  is_band_member((split_part(name, '/', 1))::integer)
+)
+WITH CHECK (
+  bucket_id = 'song-audio' AND
+  is_band_member((split_part(name, '/', 1))::integer)
+);
+
+CREATE POLICY "Band members can delete song audio"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'song-audio' AND
+  is_band_member((split_part(name, '/', 1))::integer)
+);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -324,6 +324,7 @@ export type Database = {
       songs: {
         Row: {
           artist: string | null
+          audio_url: string | null
           band_id: number
           shared_band_notes: string | null
           created_at: string
@@ -335,6 +336,7 @@ export type Database = {
         }
         Insert: {
           artist?: string | null
+          audio_url?: string | null
           band_id: number
           shared_band_notes?: string | null
           created_at?: string
@@ -346,6 +348,7 @@ export type Database = {
         }
         Update: {
           artist?: string | null
+          audio_url?: string | null
           band_id?: number
           shared_band_notes?: string | null
           created_at?: string


### PR DESCRIPTION
## Summary
This PR adds the ability to upload, manage, and store audio files for songs. Users can now upload audio files when creating or editing songs, with files stored in Supabase Storage and URLs persisted in the database.

## Key Changes

- **New `AudioFileInput` component** (`components/AudioFileInput.tsx`): A reusable React component for audio file selection with preview functionality. Supports uploading new files, replacing existing audio, and removing audio with a clean UI using Material-UI components.

- **Audio upload/delete utilities**: Added `uploadSongAudio()` and `deleteSongAudio()` helper functions in both `AddSongForm` and `EditSongForm` to handle Supabase Storage operations with proper error handling.

- **Updated song forms**: Integrated `AudioFileInput` into both `AddSongForm` and `EditSongForm` to allow users to manage audio files during song creation and editing.

- **Database schema**: Added `audio_url` column to the `songs` table via migration to store audio file URLs.

- **Storage bucket & policies**: Created `song-audio` Supabase Storage bucket with RLS policies that restrict upload, update, and delete operations to authenticated band members only (verified via `is_band_member()` function).

- **Form component enhancement**: Updated `Form` component to support optional `extraContent` prop for rendering additional form sections like the audio input.

- **Type definitions**: Updated Supabase types to include the new `audio_url` field in song rows.

## Implementation Details

- Audio files are stored in Supabase Storage under `{bandId}/{uuid}.{extension}` paths to organize files by band and ensure uniqueness.
- The component creates object URLs for preview functionality and properly cleans them up to prevent memory leaks.
- When replacing audio, the old file is deleted from storage before uploading the new one.
- Audio upload errors are caught and displayed to users without blocking the form submission flow.
- The hidden file input accepts only audio MIME types via the `accept="audio/*"` attribute.

https://claude.ai/code/session_01WerMDQfJS2kuGcGVvJCJD9