### PR TITLE
Add forgot password feature

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -8,6 +8,7 @@ export async function GET(request: Request) {
   // https://supabase.com/docs/guides/auth/auth-helpers/nextjs#managing-sign-in-with-code-exchange
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get('code')
+  const next = requestUrl.searchParams.get('next') ?? '/'
 
   if (code) {
     const cookieStore = cookies()
@@ -15,6 +16,5 @@ export async function GET(request: Request) {
     await supabase.auth.exchangeCodeForSession(code)
   }
 
-  // URL to redirect to after sign in process completes
-  return NextResponse.redirect(requestUrl.origin)
+  return NextResponse.redirect(`${requestUrl.origin}${next}`)
 }

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,27 @@
+import AuthCard from '@/components/layout/AuthCard';
+import ForgotPasswordForm from '@/components/forms/ForgotPasswordForm';
+import Box from '@mui/material/Box';
+
+interface ForgotPasswordPageProps {
+  searchParams: {
+    message: string;
+  };
+}
+
+export default function ForgotPasswordPage({
+  searchParams,
+}: Readonly<ForgotPasswordPageProps>) {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
+      <AuthCard
+        title="Forgot your password?"
+        subtitle="Enter your email to receive a password reset link"
+        footerText="Remember your password?"
+        footerLinkText="Log in"
+        footerLinkHref="/login"
+      >
+        <ForgotPasswordForm errorMessage={searchParams.message} />
+      </AuthCard>
+    </Box>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,8 @@ import { GeistSans } from 'geist/font/sans';
 import { ReactNode } from 'react';
 import './globals.css';
 
+export const dynamic = 'force-dynamic';
+
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
   : 'http://localhost:3000';

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -17,8 +17,7 @@ export default function LoginPage({ searchParams }: Readonly<LoginPageProps>) {
         footerText="Don't have an account?"
         footerLinkText="Sign up"
         footerLinkHref="/signup"
-        secondaryFooterText="Forgot your password?"
-        secondaryFooterLinkText="Reset it"
+        secondaryFooterLinkText="Forgot Password?"
         secondaryFooterLinkHref="/forgot-password"
       >
         <LoginForm errorMessage={searchParams.message} />

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -17,6 +17,9 @@ export default function LoginPage({ searchParams }: Readonly<LoginPageProps>) {
         footerText="Don't have an account?"
         footerLinkText="Sign up"
         footerLinkHref="/signup"
+        secondaryFooterText="Forgot your password?"
+        secondaryFooterLinkText="Reset it"
+        secondaryFooterLinkHref="/forgot-password"
       >
         <LoginForm errorMessage={searchParams.message} />
       </AuthCard>

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,19 @@
+import AuthCard from '@/components/layout/AuthCard';
+import ResetPasswordForm from '@/components/forms/ResetPasswordForm';
+import Box from '@mui/material/Box';
+
+export default function ResetPasswordPage() {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
+      <AuthCard
+        title="Reset your password"
+        subtitle="Enter your new password below"
+        footerText="Remember your password?"
+        footerLinkText="Log in"
+        footerLinkHref="/login"
+      >
+        <ResetPasswordForm />
+      </AuthCard>
+    </Box>
+  );
+}

--- a/components/forms/ForgotPasswordForm.tsx
+++ b/components/forms/ForgotPasswordForm.tsx
@@ -1,0 +1,51 @@
+import { createClient } from '@/utils/supabase/server';
+import EmailIcon from '@mui/icons-material/Email';
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { useMemo } from 'react';
+import { FieldValues } from 'react-hook-form';
+import Form, { FormField } from '../design/Form';
+
+interface ForgotPasswordFormProps {
+  errorMessage?: string;
+}
+
+export default function ForgotPasswordForm({ errorMessage }: Readonly<ForgotPasswordFormProps>) {
+  const formFields: FormField[] = useMemo(
+    () => [
+      {
+        fieldType: 'text' as FormField['fieldType'],
+        name: 'email',
+        label: 'Email',
+        fullWidth: true,
+        required: true,
+      },
+    ],
+    []
+  );
+
+  async function onSuccess(data: FieldValues) {
+    'use server';
+
+    const { email } = data;
+    const origin = headers().get('origin');
+    const cookieStore = cookies();
+    const supabase = createClient(cookieStore);
+
+    await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${origin}/auth/callback?next=/reset-password`,
+    });
+
+    return redirect('/forgot-password?message=Check your email for a password reset link');
+  }
+
+  return (
+    <Form
+      onSuccess={onSuccess}
+      formFields={formFields}
+      errorMessage={errorMessage}
+      saveButtonLabel="Send Reset Link"
+      saveButtonIcon={<EmailIcon />}
+    />
+  );
+}

--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -1,9 +1,6 @@
 import { createClient } from '@/utils/supabase/server';
 import LoginIcon from '@mui/icons-material/Login';
-import Box from '@mui/material/Box';
-import Link from '@mui/material/Link';
 import { cookies } from 'next/headers';
-import NextLink from 'next/link';
 import { redirect } from 'next/navigation';
 import { useMemo } from 'react';
 import { FieldValues } from 'react-hook-form';
@@ -61,19 +58,6 @@ export default function LoginForm({ errorMessage }: Readonly<LoginFormProps>) {
       errorMessage={errorMessage}
       saveButtonLabel="Login"
       saveButtonIcon={<LoginIcon />}
-      extraContent={
-        <Box sx={{ textAlign: 'right', mb: 1 }}>
-          <Link
-            component={NextLink}
-            href="/forgot-password"
-            underline="hover"
-            variant="body2"
-            color="text.secondary"
-          >
-            Forgot your password?
-          </Link>
-        </Box>
-      }
     />
   );
 }

--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -1,6 +1,9 @@
 import { createClient } from '@/utils/supabase/server';
 import LoginIcon from '@mui/icons-material/Login';
+import Box from '@mui/material/Box';
+import Link from '@mui/material/Link';
 import { cookies } from 'next/headers';
+import NextLink from 'next/link';
 import { redirect } from 'next/navigation';
 import { useMemo } from 'react';
 import { FieldValues } from 'react-hook-form';
@@ -58,6 +61,19 @@ export default function LoginForm({ errorMessage }: Readonly<LoginFormProps>) {
       errorMessage={errorMessage}
       saveButtonLabel="Login"
       saveButtonIcon={<LoginIcon />}
+      extraContent={
+        <Box sx={{ textAlign: 'right', mb: 1 }}>
+          <Link
+            component={NextLink}
+            href="/forgot-password"
+            underline="hover"
+            variant="body2"
+            color="text.secondary"
+          >
+            Forgot your password?
+          </Link>
+        </Box>
+      }
     />
   );
 }

--- a/components/forms/ResetPasswordForm.tsx
+++ b/components/forms/ResetPasswordForm.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { createClient } from '@/utils/supabase/client';
+import LockResetIcon from '@mui/icons-material/LockReset';
+import { useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { FieldValues } from 'react-hook-form';
+import Form, { FormField } from '../design/Form';
+
+export default function ResetPasswordForm() {
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const router = useRouter();
+
+  const formFields: FormField[] = useMemo(
+    () => [
+      {
+        fieldType: 'password' as FormField['fieldType'],
+        name: 'password',
+        label: 'New Password',
+        fullWidth: true,
+        required: true,
+      },
+      {
+        fieldType: 'password' as FormField['fieldType'],
+        name: 'confirmPassword',
+        label: 'Confirm New Password',
+        fullWidth: true,
+        required: true,
+      },
+    ],
+    []
+  );
+
+  async function onSuccess(data: FieldValues) {
+    const { password, confirmPassword } = data;
+
+    if (password !== confirmPassword) {
+      setErrorMessage('Passwords do not match');
+      return;
+    }
+
+    const supabase = createClient();
+    const { error } = await supabase.auth.updateUser({ password });
+
+    if (error) {
+      setErrorMessage(error.message);
+      return;
+    }
+
+    router.push('/login?message=Password updated successfully. Please log in.');
+  }
+
+  return (
+    <Form
+      onSuccess={onSuccess}
+      formFields={formFields}
+      errorMessage={errorMessage}
+      saveButtonLabel="Update Password"
+      saveButtonIcon={<LockResetIcon />}
+    />
+  );
+}

--- a/components/layout/AuthCard.tsx
+++ b/components/layout/AuthCard.tsx
@@ -40,20 +40,20 @@ export default function AuthCard({
           {subtitle}
         </Typography>
         {children}
-        <Typography variant="body2" color="text.secondary" mt={3}>
-          {footerText}{' '}
-          <Link component={NextLink} href={footerLinkHref} underline="hover" color="primary">
-            {footerLinkText}
-          </Link>
-        </Typography>
         {secondaryFooterLinkText && secondaryFooterLinkHref && (
-          <Typography variant="body2" color="text.secondary" mt={1}>
-            {secondaryFooterText}{' '}
+          <Typography variant="body2" color="text.secondary" mt={3}>
+            {secondaryFooterText && <>{secondaryFooterText}{' '}</>}
             <Link component={NextLink} href={secondaryFooterLinkHref} underline="hover" color="primary">
               {secondaryFooterLinkText}
             </Link>
           </Typography>
         )}
+        <Typography variant="body2" color="text.secondary" mt={1}>
+          {footerText}{' '}
+          <Link component={NextLink} href={footerLinkHref} underline="hover" color="primary">
+            {footerLinkText}
+          </Link>
+        </Typography>
       </CardContent>
     </Card>
   );

--- a/components/layout/AuthCard.tsx
+++ b/components/layout/AuthCard.tsx
@@ -13,6 +13,9 @@ interface AuthCardProps {
   footerText: string;
   footerLinkText: string;
   footerLinkHref: string;
+  secondaryFooterText?: string;
+  secondaryFooterLinkText?: string;
+  secondaryFooterLinkHref?: string;
   children: ReactNode;
 }
 
@@ -22,6 +25,9 @@ export default function AuthCard({
   footerText,
   footerLinkText,
   footerLinkHref,
+  secondaryFooterText,
+  secondaryFooterLinkText,
+  secondaryFooterLinkHref,
   children,
 }: AuthCardProps) {
   return (
@@ -40,6 +46,14 @@ export default function AuthCard({
             {footerLinkText}
           </Link>
         </Typography>
+        {secondaryFooterLinkText && secondaryFooterLinkHref && (
+          <Typography variant="body2" color="text.secondary" mt={1}>
+            {secondaryFooterText}{' '}
+            <Link component={NextLink} href={secondaryFooterLinkHref} underline="hover" color="primary">
+              {secondaryFooterLinkText}
+            </Link>
+          </Typography>
+        )}
       </CardContent>
     </Card>
   );

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,9 @@
 const nextConfig = {
   // set to false due to compatibility issues with react-beautiful-dnd
   reactStrictMode: false,
+  turbopack: {
+    root: __dirname,
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
- Add /forgot-password page with email form that sends a Supabase reset link
- Add /reset-password page with new-password form that calls supabase.auth.updateUser
- Update /auth/callback to support a `next` query param so recovery emails land on /reset-password
- Add "Forgot your password?" link to the login form

https://claude.ai/code/session_01MMb3CxnAVnqwTtAYvRvcDq